### PR TITLE
Enable GEE with working independence

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -410,12 +410,6 @@ and the corresponding gradient function to constraint_grad_fn.")
       if (use_both_cov) {
         
         #adjustment factor from guo GEE paper (https://doi.org/10.1002/sim.2161)
-        if(is.null(cluster)){
-          score_adj <- n/(n - 1)
-        } else{
-          nclust <- length(unique(cluster))
-          score_adj <- nclust/(nclust - 1)
-        }
         alt_score_stat <- get_score_stat(Y = Y_test,
                                          X_cup = X_cup,
                                          X = X,
@@ -430,7 +424,7 @@ and the corresponding gradient function to constraint_grad_fn.")
                                          p = p, 
                                          I_inv=I_inv,
                                          Dy = just_wald_things$Dy,
-                                         cluster = cluster)*score_adj
+                                         cluster = cluster)
         
         
         which_row <- which((as.numeric(coefficients$k) == as.numeric(test_kj$k[test_ind]))&

--- a/R/get_score_stat.R
+++ b/R/get_score_stat.R
@@ -92,10 +92,18 @@ get_score_stat <- function(Y,
   #remove indexes corresponding to convenience constraint
   score <- score[-indexes_to_remove, , drop =FALSE]
   
+  #adjustment factor from Guo et al. GEE paper (https://doi.org/10.1002/sim.2161)
+  if(is.null(cluster)){
+    score_adj <- n/(n - 1)
+  } else{
+    nclust <- length(unique(cluster))
+    score_adj <- nclust/(nclust - 1)
+  }
+  
   #slightly fancy calculation of numerator and denominator of score stat:
   outside <- Matrix::crossprod(score, I_inv_H)
   inside <- Matrix::crossprod(I_inv_H, Dy) %*% I_inv_H
-  score_stat <- as.numeric(as.matrix(outside^2/inside))
+  score_stat <- as.numeric(as.matrix(outside^2/inside))*score_adj
   
   return(as.numeric(score_stat))
 }

--- a/R/get_score_stat.R
+++ b/R/get_score_stat.R
@@ -14,7 +14,8 @@ get_score_stat <- function(Y,
                            n,
                            p,
                            I_inv = NULL, #previously computed I_inv, if desired
-                           Dy = NULL #previously computed estimate of score covariance, if desired
+                           Dy = NULL, #previously computed estimate of score covariance, if desired
+                           cluster = NULL #numeric vector giving cluster membership for GEE
                            ){
   scores <- vector(n,mode = "list")
   
@@ -38,6 +39,12 @@ get_score_stat <- function(Y,
     X_cup_i <- X_cup[(i - 1)*J + 1:J, ]
     scores[[i]] <- Matrix::crossprod(X_cup_i, Y[i,] - exp(X_cup_i %*% B_cup + z[i]))
     
+  }
+  
+  if(!is.null(cluster)){
+    scores <- lapply(unique(cluster),
+                     function(i) 
+                       Reduce("+",scores[cluster == i]))
   }
   
   #compute derivative of constraint wrt (long/vector format) B 

--- a/R/micro_wald.R
+++ b/R/micro_wald.R
@@ -12,7 +12,8 @@ micro_wald <- function(Y,
                        return_info = TRUE,
                        return_Dy = TRUE,
                        return_sandwich = FALSE,
-                       j_ref = NULL){
+                       j_ref = NULL,
+                       cluster = NULL){
   n <- nrow(Y)
   J <- ncol(Y)
   p <- ncol(X)
@@ -54,6 +55,13 @@ micro_wald <- function(Y,
                      # print(i);
                      Y_diff[i,,drop = FALSE]%*%
                        X_cup[(i - 1)*J + 1:J,]})
+  
+  if(!is.null(cluster)){
+    scores <- lapply(unique(cluster),
+                     function(i) 
+                       Reduce("+",scores[cluster == i]))
+  }
+
   
   score_mat <- do.call(rbind,scores)
   score_mat <- methods::as(score_mat,"sparseMatrix")

--- a/R/score_test.R
+++ b/R/score_test.R
@@ -198,17 +198,6 @@ retrying with smaller penalty scaling parameter tau and larger inner_maxit.")
                  I_inv = I_inv,
                  Dy = Dy,
                  cluster = cluster)
-
-  #adjustment factor from guo GEE paper (https://doi.org/10.1002/sim.2161)
-  if(is.null(cluster)){
-    score_adj <- n/(n - 1)
-  } else{
-    nclust <- length(unique(cluster))
-    score_adj <- nclust/(nclust - 1)
-  }
-
-  score_stat <- score_stat*score_adj
-
  
   if(!return_both_score_pvals){ #typically we want only one score p-value
                                 #(using only one version of information matrix)
@@ -244,7 +233,7 @@ retrying with smaller penalty scaling parameter tau and larger inner_maxit.")
                        I_inv = NULL,
                        Dy = Dy)
 
-      score_stat_with_null_info <- score_stat_with_null_info*score_adj
+      score_stat_with_null_info <- score_stat_with_null_info
 
       return(list("score_stat" = score_stat,
                   "pval" = pchisq(score_stat,1,lower.tail = FALSE),

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -9,6 +9,7 @@ emuFit(
   X = NULL,
   formula = NULL,
   data = NULL,
+  cluster = NULL,
   penalize = TRUE,
   B = NULL,
   fitted_model = NULL,
@@ -49,6 +50,10 @@ emuFit(
 \item{formula}{a one-sided formula specifying the form of the mean model to be fit}
 
 \item{data}{an n x p data frame containing variables given in \code{formula}}
+
+\item{cluster}{a numeric vector giving cluster membership for each row of Y to
+be used in computing GEE test statistics. Default is NULL, in which case rows of
+Y are treated as independent.}
 
 \item{penalize}{logical: should Firth penalty be used in fitting model? Default is TRUE.}
 

--- a/man/score_test.Rd
+++ b/man/score_test.Rd
@@ -28,7 +28,8 @@ score_test(
   trackB = FALSE,
   I_inv = NULL,
   Dy = NULL,
-  return_both_score_pvals = FALSE
+  return_both_score_pvals = FALSE,
+  cluster = NULL
 )
 }
 \arguments{
@@ -107,6 +108,10 @@ under null, which we recommend.}
 information matrix computed from full model fit and from null model fits? Default is
 FALSE. This parameter is used for simulations - in any applied analysis, type of
 p-value to be used should be chosen before conducting tests.}
+
+\item{cluster}{a numeric vector giving cluster membership for each row of Y to
+be used in computing GEE test statistics. Default is NULL, in which case rows of
+Y are treated as independent.}
 }
 \value{
 A list containing elements 'score_stat', 'pval', 'log_pval','niter',

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -164,6 +164,61 @@ test_that("emuFit takes formulas and actually fits a model", {
   
 })
 
+test_that("emuFit takes cluster argument without breaking ",{
+          expect_silent({
+            fitted_model_cluster <- emuFit(Y = Y,
+                                   X = X,
+                                   formula = ~group,
+                                   data = covariates,
+                                   verbose = FALSE,
+                                   B_null_tol = 1e-2,
+                                   tolerance = 0.01,
+                                   tau = 2,
+                                   return_wald_p = FALSE,
+                                   compute_cis = TRUE,
+                                   run_score_tests = TRUE, 
+                                   use_fullmodel_info = FALSE,
+                                   use_fullmodel_cov = FALSE,
+                                   return_both_score_pvals = FALSE,
+                                   cluster = rep(1:3,each = 4))
+          })
+  
+  expect_silent({
+    fitted_model_nocluster <- emuFit(Y = Y,
+                                   X = X,
+                                   formula = ~group,
+                                   data = covariates,
+                                   verbose = FALSE,
+                                   B_null_tol = 1e-2,
+                                   tolerance = 0.01,
+                                   tau = 2,
+                                   return_wald_p = FALSE,
+                                   compute_cis = TRUE,
+                                   run_score_tests = TRUE, 
+                                   use_fullmodel_info = FALSE,
+                                   use_fullmodel_cov = FALSE,
+                                   return_both_score_pvals = FALSE)
+  })
+  
+  expect_true(all(fitted_model_nocluster$coef$estimate == fitted_model_cluster$coef$estimate))
+  
+  expect_true(all(fitted_model_nocluster$coef$se != fitted_model_cluster$coef$se))
+  
+  expect_true(all(fitted_model_cluster$coef$se != fitted_model_nocluster$coef$se))
+  
+          
+          
+          
+          ## emuFit takes formulas and actually fits a model (with score tests)
+          
+          expect_true(all(fitted_model_cluster$coef$wald_p>0 & fitted_model_cluster$coef$wald_p<1))
+          expect_true(all(fitted_model_cluster$coef$pval>0 & fitted_model_cluster$coef$pval<1))
+          expect_true(inherits(fitted_model_cluster$B,"matrix"))
+          expect_true(inherits(fitted_model_cluster$Y_augmented,"matrix"))
+          expect_true(cor(fitted_model_cluster$B[2,],b[2, ]) > 0.85)
+          
+})
+
 # test_that("emuFit takes formulas and actually fits a model (no score tests) when J is large", {
 #   
 #   b1 <- 1:10

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -219,6 +219,108 @@ test_that("emuFit takes cluster argument without breaking ",{
           
 })
 
+b0 <- rnorm(J)
+b1 <- seq(1,5,length.out = J)
+b1 <- b1 - mean(b1)
+b1[3:4] <- 0
+b <- rbind(b0,b1)
+
+test_that("GEE with cluster covariance gives plausible type 1 error ",{
+  skip("Skipping -- test requires fitting models to 100 simulated datasets.")
+  set.seed(44022)
+  nsim <- 100
+  cluster <- rep(1:4, each = 3)
+  results <- data.frame(sim = rep(1:nsim,each = 2),
+                        category_num = rep(3:4,nsim),
+                        estimate = numeric(2*nsim),
+                        score_stat = numeric(2*nsim),
+                        pval = numeric(2*nsim))[-(1:(2*nsim)),]
+  results_noGEE <- results
+  for(sim in 1:nsim){
+    print(sim)
+    X <- cbind(1,rnorm(n))
+    covariates <- data.frame(group = X[,2])
+    Y <- matrix(NA,ncol = J, nrow = n)
+  
+  cluster_effs <- lapply(1:4,
+                         function(i)
+                           log(matrix(rexp(2*J),nrow= 2)))
+  
+  for(i in 1:n){
+    Y[i,] <- 0
+    while(sum(Y[i,])==0){
+    for(j in 1:J){
+      temp_mean <- exp(X[i,,drop = FALSE]%*%(b[,j,drop = FALSE] + 
+                                               cluster_effs[[ cluster[i] ]][,j]) + z[i])
+      Y[i,j] <- rnbinom(1, mu= temp_mean,size = 5)*rbinom(1,1,0.8)
+    }}
+  }
+  
+  # expect_silent({
+    fitted_model_cluster <- emuFit(Y = Y,
+                                   X = X,
+                                   formula = ~group,
+                                   data = covariates,
+                                   verbose = FALSE,
+                                   B_null_tol = 1e-2,
+                                   tolerance = 0.01,
+                                   tau = 1.2,
+                                   return_wald_p = FALSE,
+                                   compute_cis = TRUE,
+                                   run_score_tests = TRUE, 
+                                   use_fullmodel_info = FALSE,
+                                   use_fullmodel_cov = FALSE,
+                                   return_both_score_pvals = FALSE,
+                                   test_kj = data.frame(k = c(2,2),
+                                                        j = c(3,4)),
+                                   cluster = cluster)
+    
+    fitted_model_nocluster <- emuFit(Y = Y,
+                                   X = X,
+                                   formula = ~group,
+                                   data = covariates,
+                                   verbose = FALSE,
+                                   B_null_tol = 1e-2,
+                                   tolerance = 0.01,
+                                   tau = 1.2,
+                                   return_wald_p = FALSE,
+                                   compute_cis = TRUE,
+                                   run_score_tests = TRUE, 
+                                   use_fullmodel_info = FALSE,
+                                   use_fullmodel_cov = FALSE,
+                                   return_both_score_pvals = FALSE,
+                                   test_kj = data.frame(k = c(2,2),
+                                                        j = c(3,4)))
+  # })
+  
+  filtered_coef <- fitted_model_cluster$coef[!is.na(fitted_model_cluster$coef$pval),
+                                             c("category_num",
+                                               "estimate",
+                                               "score_stat",
+                                               "pval")]
+  results <- rbind(results,
+                   cbind(data.frame("sim" = rep(sim,2)),
+                         filtered_coef))
+  
+  filtered_coef_noGEE <- fitted_model_nocluster$coef[!is.na(fitted_model_nocluster$coef$pval),
+                                             c("category_num",
+                                               "estimate",
+                                               "score_stat",
+                                               "pval")]
+  results_noGEE <- rbind(results_noGEE,
+                   cbind(data.frame("sim" = rep(sim,2)),
+                         filtered_coef_noGEE))
+  
+  
+  }
+  
+  #expect somewhat conservative inference for score test with correct clustering
+  expect_true(mean(results$pval<=0.05) <= 0.05)
+  #expect fairly anti-conservative inference for score test without clustering
+  expect_true(mean(results_noGEE$pval<=0.05) >= 0.10)
+  
+})
+
 # test_that("emuFit takes formulas and actually fits a model (no score tests) when J is large", {
 #   
 #   b1 <- 1:10

--- a/tests/testthat/test-score_test.R
+++ b/tests/testthat/test-score_test.R
@@ -104,8 +104,8 @@ we do *not* get same results if we use incorrect info", {
                      p = p,
                      I_inv = diag(rep(1,18)))
 
-    expect_equal((n/(n - 1))*score_stat_with_I_inv,score_test_as_is$score_stat)
-    expect_true((n/(n - 1))*score_stat_with_other_mat !=score_test_as_is$score_stat)
+    expect_equal(score_stat_with_I_inv,score_test_as_is$score_stat)
+    expect_true(score_stat_with_other_mat !=score_test_as_is$score_stat)
 
 })
 # test_that("simple negative binomial example fits reasonably fast and returns reasonable output", {


### PR DESCRIPTION
Allow cluster dependence / GEE using the newly added 'cluster' argument for emuFit. Only working independence between rows of Y is supported.