### PR TITLE
Address issue #38, a vignette for using radEmu with clustered data (take two) 

### DIFF
--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -39,6 +39,7 @@ emuFit(
   inner_maxit = 25,
   max_step = 1,
   trackB = FALSE,
+  return_nullB = FALSE,
   return_both_score_pvals = FALSE
 )
 }
@@ -146,6 +147,8 @@ will be rescaled if a step in any parameter exceeds this value. Defaults to 0.5.
 
 \item{trackB}{logical: should values of B be recorded across optimization
 iterations and be returned? Primarily used for debugging. Default is FALSE.}
+
+\item{return_nullB}{logical: should values of B under null hypothesis be returned. Primarily used for debugging. Default is FALSE.}
 
 \item{return_both_score_pvals}{logical: should score p-values be returned using both
 information matrix computed from full model fit and from null model fits? Default is

--- a/tests/testthat/test-macro_fisher_null.R
+++ b/tests/testthat/test-macro_fisher_null.R
@@ -107,7 +107,7 @@ test_that("We take same step as we'd take using numerical derivatives when gap, 
 
   min_ratio <- min(update$update/n_update,na.rm = TRUE)
 
-  expect_equal(max_ratio,min_ratio,tolerance = 1e-4)
+  expect_equal(max_ratio,min_ratio,tolerance = 1e-3)
 
 })
 


### PR DESCRIPTION
This pull request does the following:

- updates `emuFit()` to take in the any kind of vector as the `cluster` argument
- check that all of the different inputs to cluster provide the same results
- add the first draft of a vignette explaining how to use the cluster argument and why we want to account for data with cluster dependence