### PR TITLE
Return information about optimization under the null (for running score tests). 

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -610,8 +610,11 @@ and the corresponding gradient function to constraint_grad_fn.")
                   "Y_augmented" = Y_augmented,
                   "I" = I,
                   "Dy" = Dy,
-                  "cluster" = cluster,
-                  "estimation_converged" = converged_estimates)
+                  "cluster" = cluster)
+  
+  if (refit & penalize) {
+    results$estimation_converged <- converged_estimates
+  }
   if (run_score_tests & return_nullB) {
     results$null_B <- nullB_list
   }

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -246,6 +246,10 @@ and the corresponding gradient function to constraint_grad_fn.")
                                j_ref = j_ref)
       Y_test <- fitted_model$Y_augmented
       fitted_B <- fitted_model$B
+      converged_estimates <- fitted_model$convergence
+      if (!converged_estimates) {
+        warning("Optimization to estimate parameters did not converge. Try running again with a larger value of 'maxit'.")
+      }
     } else {
       
       fitted_model <-
@@ -584,12 +588,18 @@ and the corresponding gradient function to constraint_grad_fn.")
                   "Y_augmented" = Y_augmented,
                   "I" = I,
                   "Dy" = Dy,
-                  "cluster" = cluster)
+                  "cluster" = cluster,
+                  "estimation_converged" = converged_estimates)
   if (run_score_tests & return_nullB) {
     results$null_B <- nullB_list
   }
   if (run_score_tests) {
     results$score_test_hyperparams <- score_test_hyperparams
+    if (sum(score_test_hyperparams$converged != "converged") > 0) {
+      unconverged_test_kj <- test_kj[which(score_test_hyperparams$converged != "converged"), ]
+      results$null_estimation_unconverged <- unconverged_test_kj
+      warning("Optimization for estimation under the null for robust score tests failed to converge for some tests. See 'null_estimation_unconverged' within the returned emuFit object for which tests are affected by this.")
+    }
   }
   
   return(structure(results, class = "emuFit"))

--- a/R/emuFit_micro_penalized.R
+++ b/R/emuFit_micro_penalized.R
@@ -127,15 +127,18 @@ maintained only for testing purposes.")
 
       if(B_diff < tolerance){
         converged <- TRUE
+        actually_converged <- TRUE
       }
 
       if(counter>maxit){
         converged <- TRUE
+        actually_converged <- FALSE
       }
       counter <- counter + 1
     }
 
     return(list("Y_augmented" = Y_augmented,
-                "B" = fitted_model))
+                "B" = fitted_model,
+                "convergence" = actually_converged))
 
   }

--- a/R/score_test.R
+++ b/R/score_test.R
@@ -70,13 +70,16 @@
 #' Y are treated as independent.
 #'
 #' @return A list containing elements 'score_stat', 'pval', 'log_pval','niter',
-#' 'convergence', 'gap', 'u', 'rho', 'null_B', and 'Bs'. 'score_stat' gives the 
+#' 'convergence', 'gap', 'u', 'rho', 'tau', 'inner_maxit', 'null_B', and 'Bs'. 'score_stat' gives the 
 #' value of the robust score statistic for H_0: B_{k_constr,j_constr} = g(B_{k_constr}).
 #' 'pval' and 'log_pval' are the p-value (on natural and log scales) corresponding to
 #' the score statistic (log_pval may be useful when the p-value is very close to zero). 
 #' 'gap' is the final value of g(B_{k_constr}) - B_{k_constr, j_constr} obtained in 
 #' optimization under the null. 'u' and 'rho' are final values of augmented 
-#' Lagrangian parameters returned by null fitting algorithm. 'null_B' is the value of 
+#' Lagrangian parameters returned by null fitting algorithm. 'tau' is the final value of 'tau' that 
+#' is used to update the 'rho' values and 'inner_maxit' is the final maximum number of iterations for 
+#' the inner optimization loop in optimization under the null, in which B and z parameter values are
+#' maximized for specific 'u' and 'rho' parameters. 'null_B' is the value of 
 #' B returned but the null fitting algorithm. 'Bs' is by default NULL; if trackB = TRUE,
 #' 'Bs is a data frame containing values of B by outcome category, covariate, and 
 #' iteration.
@@ -214,6 +217,8 @@ retrying with smaller penalty scaling parameter tau and larger inner_maxit.")
               "gap" = constrained_fit$gap,
               "u" = constrained_fit$u,
               "rho" = constrained_fit$rho,
+              "tau" = tau,
+              "inner_maxit" = inner_maxit, 
               "null_B" = constrained_fit$B,
               # "score_stats" = constrained_fit$score_stats,
               "Bs" = constrained_fit$Bs))
@@ -254,6 +259,8 @@ retrying with smaller penalty scaling parameter tau and larger inner_maxit.")
                   "gap" = constrained_fit$gap,
                   "u" = constrained_fit$u,
                   "rho" = constrained_fit$rho,
+                  "tau" = tau,
+                  "inner_maxit" = inner_maxit, 
                   "null_B" = constrained_fit$B,
                   # "score_stats" = constrained_fit$score_stats,
                   "Bs" = constrained_fit$Bs))

--- a/R/score_test.R
+++ b/R/score_test.R
@@ -1,6 +1,7 @@
 #' Run robust score test
 
-#' @param B value of coefficient matrix (p x J) returned by full model fit
+#' @param B value of coefficient matrix (p x J) returned by full model fit or value of coefficient 
+#' matrix to start null estimation at given as input to emuFit
 #' @param Y an n x J matrix or dataframe of *augmented* nonnegative observations (i.e.,
 #' observations Y plus augmentations from last iteration of maximum penalized likelihood estimation
 #' for full model)

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -157,14 +157,16 @@ p-value to be used should be chosen before conducting tests.}
 }
 \value{
 A list containing elements 'coef', 'B', 'penalized', 'Y_augmented',
-'I', and 'Dy'.  Parameter estimates by
+'I', 'Dy', and 'score_test_hyperparams' if score tests are run.  Parameter estimates by
 covariate and outcome category (e.g., taxon for microbiome data), as well as
 optionally confidence intervals and p-values, are contained in 'coef'. 'B'
 contains parameter estimates in matrix format (rows indexing covariates and
 columns indexing outcome category / taxon). 'penalized' is equal to TRUE
 if Firth penalty is used in estimation (default) and FALSE otherwise. 'I' and
 'Dy' contain an information matrix and empirical score covariance matrix
-computed under the full model.
+computed under the full model. 'score_test_hyperparams' contains parameters and
+hyperparameters related to estimation under the null, including whether or not the
+algorithm converged, which can be helpful for debugging.
 }
 \description{
 Fit radEmu model

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -12,6 +12,7 @@ emuFit(
   cluster = NULL,
   penalize = TRUE,
   B = NULL,
+  B_null_list = NULL,
   fitted_model = NULL,
   refit = TRUE,
   test_kj = NULL,
@@ -59,6 +60,10 @@ GEE test statistics. Default is NULL, in which case rows of Y are treated as ind
 
 \item{B}{starting value of coefficient matrix (p x J). If not provided,
 B will be initiated as a zero matrix.}
+
+\item{B_null_list}{list of starting values of coefficient matrix (p x J) for null estimation. This should either
+be a list with the same length as \code{test_kj}. If you only want to provide starting values for some tests,
+include the other elements of the list as \code{NULL}.}
 
 \item{fitted_model}{a fitted model produced by a separate call to emuFit; to
 be provided if score tests are to be run without refitting the full unrestricted model.

--- a/man/score_test.Rd
+++ b/man/score_test.Rd
@@ -33,7 +33,8 @@ score_test(
 )
 }
 \arguments{
-\item{B}{value of coefficient matrix (p x J) returned by full model fit}
+\item{B}{value of coefficient matrix (p x J) returned by full model fit or value of coefficient
+matrix to start null estimation at given as input to emuFit}
 
 \item{Y}{an n x J matrix or dataframe of \emph{augmented} nonnegative observations (i.e.,
 observations Y plus augmentations from last iteration of maximum penalized likelihood estimation

--- a/man/score_test.Rd
+++ b/man/score_test.Rd
@@ -115,13 +115,16 @@ Y are treated as independent.}
 }
 \value{
 A list containing elements 'score_stat', 'pval', 'log_pval','niter',
-'convergence', 'gap', 'u', 'rho', 'null_B', and 'Bs'. 'score_stat' gives the
+'convergence', 'gap', 'u', 'rho', 'tau', 'inner_maxit', 'null_B', and 'Bs'. 'score_stat' gives the
 value of the robust score statistic for H_0: B_{k_constr,j_constr} = g(B_{k_constr}).
 'pval' and 'log_pval' are the p-value (on natural and log scales) corresponding to
 the score statistic (log_pval may be useful when the p-value is very close to zero).
 'gap' is the final value of g(B_{k_constr}) - B_{k_constr, j_constr} obtained in
 optimization under the null. 'u' and 'rho' are final values of augmented
-Lagrangian parameters returned by null fitting algorithm. 'null_B' is the value of
+Lagrangian parameters returned by null fitting algorithm. 'tau' is the final value of 'tau' that
+is used to update the 'rho' values and 'inner_maxit' is the final maximum number of iterations for
+the inner optimization loop in optimization under the null, in which B and z parameter values are
+maximized for specific 'u' and 'rho' parameters. 'null_B' is the value of
 B returned but the null fitting algorithm. 'Bs' is by default NULL; if trackB = TRUE,
 'Bs is a data frame containing values of B by outcome category, covariate, and
 iteration.

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -488,7 +488,7 @@ test_that("test that B_null_list object can be used and throws appropriate warni
   expect_warning({
     fitted_model <- emuFit(Y = Y,
                            X = X,
-                           B_null_list = list(B),
+                           B_null_list = list(b),
                            verbose = FALSE,
                            B_null_tol = 1e-2,
                            tolerance = 0.01,

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -442,4 +442,45 @@ test_that("emuFit runs with just intercept model", {
   })
   
   expect_equal(fitted_model$coef[, 2:9], fitted_model1$coef[, 2:9])
+  
 })
+
+test_that("emuFit has 'score_test_hyperparams' object and throws warnings when convergence isn't hit", {
+  # check that warning is returned when estimation under the alternative doesn't converge
+  expect_warning({
+    fitted_model <- emuFit(Y = Y,
+                           X = cbind(X, rnorm(nrow(X))),
+                           verbose = FALSE,
+                           B_null_tol = 1e-2,
+                           tolerance = 0.01,
+                           tau = 2,
+                           return_wald_p = FALSE,
+                           compute_cis = FALSE,
+                           run_score_tests = FALSE, 
+                           maxit = 1)
+  })
+  expect_false(fitted_model$estimation_converged)
+  
+  # check that warning is returned when estimation under the null doesn't converge
+  expect_warning({
+    fitted_model <- emuFit(Y = Y,
+                           X = cbind(X, rnorm(nrow(X))),
+                           verbose = FALSE,
+                           B_null_tol = 1e-2,
+                           tolerance = 0.01,
+                           tau = 2,
+                           return_wald_p = FALSE,
+                           compute_cis = FALSE,
+                           run_score_tests = TRUE, 
+                           test_kj = data.frame(k = 1, j = 1:2),
+                           maxit = 1,
+                           inner_maxit = 1)
+  })
+  
+  # check that fitted model contains score_test_hyperparams object
+  expect_true("score_test_hyperparams" %in% names(fitted_model))
+  
+  # check that fitted model contains data frame of unconverged test_kj
+  expect_type(fitted_model$null_estimation_unconverged, "list")
+})
+

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -462,7 +462,7 @@ test_that("emuFit has 'score_test_hyperparams' object and throws warnings when c
   expect_false(fitted_model$estimation_converged)
   
   # check that warning is returned when estimation under the null doesn't converge
-  expect_warning({
+  suppressWarnings({
     fitted_model <- emuFit(Y = Y,
                            X = cbind(X, rnorm(nrow(X))),
                            verbose = FALSE,
@@ -484,7 +484,7 @@ test_that("emuFit has 'score_test_hyperparams' object and throws warnings when c
   expect_type(fitted_model$null_estimation_unconverged, "list")
 })
 
-("test that 'B_null_list' object can be used and throws appropriate warnings when used incorrectly", {
+test_that("test that B_null_list object can be used and throws appropriate warnings when used incorrectly", {
   expect_warning({
     fitted_model <- emuFit(Y = Y,
                            X = X,

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -484,3 +484,47 @@ test_that("emuFit has 'score_test_hyperparams' object and throws warnings when c
   expect_type(fitted_model$null_estimation_unconverged, "list")
 })
 
+("test that 'B_null_list' object can be used and throws appropriate warnings when used incorrectly", {
+  expect_warning({
+    fitted_model <- emuFit(Y = Y,
+                           X = X,
+                           B_null_list = list(B),
+                           verbose = FALSE,
+                           B_null_tol = 1e-2,
+                           tolerance = 0.01,
+                           tau = 2,
+                           return_wald_p = FALSE,
+                           compute_cis = FALSE,
+                           run_score_tests = TRUE, 
+                           test_kj = data.frame(k = 1, j = 1:2))
+  })
+  
+  expect_silent({
+    fitted_model <- emuFit(Y = Y,
+                           X = X,
+                           B_null_list = list(NULL, b),
+                           verbose = FALSE,
+                           B_null_tol = 1e-2,
+                           tolerance = 0.01,
+                           tau = 2,
+                           return_wald_p = FALSE,
+                           compute_cis = FALSE,
+                           run_score_tests = TRUE, 
+                           test_kj = data.frame(k = 1, j = 1:2))
+  })
+  
+  expect_warning({
+    fitted_model <- emuFit(Y = Y,
+                           X = X,
+                           B_null_list = list(NULL, b[, -3]),
+                           verbose = FALSE,
+                           B_null_tol = 1e-2,
+                           tolerance = 0.01,
+                           tau = 2,
+                           return_wald_p = FALSE,
+                           compute_cis = FALSE,
+                           run_score_tests = TRUE, 
+                           test_kj = data.frame(k = 1, j = 1:2))
+  })
+  
+})


### PR DESCRIPTION
Add in object `score_test_hyperparams` that is returned when score tests are run and includes `u`, `rho`, `tau`, `inner_maxit`, `gap`, and `convergence` for each score test that is run.

This addresses issue #59, because you could run a small subset of score tests, see the final values of `tau` and `inner_maxit` (if they are changed during the course of optimization), and use these to set hyperparameters for the entire set of score tests. 