### PR TITLE
add update to re-order covariate data if it has different rownames than response data

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -179,6 +179,14 @@ covariates in formula must be provided.")
     }
   }
   
+  # check that if X and Y have rownames, they match 
+  if (!is.null(rownames(Y)) & !is.null(rownames(X))) {
+    if (all.equal(rownames(Y), rownames(X)) != TRUE) {
+      message("There is a different row ordering between covariate data and response data. Covariate data will be reordered to match response data.")
+      X <- X[rownames(Y), ]
+    }
+  }
+  
   if (min(rowSums(Y))==0) {
     stop("Some rows of Y consist entirely of zeroes, meaning that some samples
 have no observations. These samples must be excluded before fitting model.")

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -528,3 +528,29 @@ test_that("test that B_null_list object can be used and throws appropriate warni
   })
   
 })
+
+test_that("emuFit reorders X and X and Y rownames don't match", {
+  dat1 <- data.frame(group = c(covariates$group[12], covariates$group[1:11]))
+  rownames(dat1) <- paste0("sample", c(12, 1:11)) 
+  dat2 <- covariates
+  rownames(dat2) <- paste0("sample", 1:12)
+  rownames(Y) <- paste0("sample", 1:12)
+  
+  expect_message({
+    fitted_model1 <- emuFit(formula = ~ group,
+                            data = dat1,
+                            Y = Y,
+                            compute_cis = FALSE,
+                            run_score_tests = FALSE)
+  })
+  
+  expect_silent({
+    fitted_model2 <- emuFit(formula = ~ group,
+                            data = dat2,
+                            Y = Y,
+                            compute_cis = FALSE,
+                            run_score_tests = FALSE)
+  })
+  
+  expect_true(all.equal(fitted_model1$coef, fitted_model2$coef))
+})


### PR DESCRIPTION
- add message and fix in `emuFit` when `Y` and `X` have differing row names 
- add test for this functionality 