### PR TITLE
add check to `emuFit()` to throw an error for a category with only zero counts across samples

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -192,6 +192,11 @@ covariates in formula must be provided.")
 have no observations. These samples must be excluded before fitting model.")
   }
   
+  if (min(colSums(Y)) == 0) {
+    stop("Some columns of Y consist entirely of zeroes, meaning that some categories have zero counts for all samples. These
+         categories must be excluded before fitting the model.")
+  }
+  
   #check that cluster is correctly type if provided
   if(!is.null(cluster)){
     if(length(cluster)!=nrow(Y)){

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -554,3 +554,23 @@ test_that("emuFit reorders X and X and Y rownames don't match", {
   
   expect_true(all.equal(fitted_model1$coef, fitted_model2$coef))
 })
+
+test_that("emuFit throws error when there is a category with all zero counts", {
+  
+  Y_zero <- Y
+  Y_zero[, 1] <- 0
+  
+  expect_error({
+    fitted_model <- emuFit(Y = Y_zero,
+                           X = X,
+                           formula = ~group,
+                           data = covariates,
+                           verbose = FALSE,
+                           B_null_tol = 1e-2,
+                           tolerance = 0.01,
+                           tau = 2,
+                           return_wald_p = FALSE,
+                           compute_cis = FALSE,
+                           run_score_tests = FALSE)
+  }) 
+})

--- a/vignettes/intro_radEmu.Rmd
+++ b/vignettes/intro_radEmu.Rmd
@@ -122,6 +122,18 @@ Again, while we would generally fit a model using all of our samples, for this t
 ch_study_obs <- which(wirbel_sample$Country %in% c("CHI"))
 ```
 
+Next, we want to confirm that all samples have at least one non-zero count across the categories we've chosen and that all categories have at least one non-zero count across the samples we've chosen.
+
+```{r}
+small_Y <- wirbel_otu[ch_study_obs, restricted_mOTU_names]
+sum(rowSums(small_Y) == 0) # no samples have a count sum of 0 
+sum(colSums(small_Y) == 0) # one category has a count sum of 0
+
+category_to_rm <- which(colSums(small_Y) == 0)
+small_Y <- small_Y[, -category_to_rm]
+sum(colSums(small_Y) == 0)
+```
+
 The function that we use to fit our model is called `emuFit`. It can accept your data in various forms, and here we will show how to use it with data frames as input. Check out the `phyloseq` vignette if you'd like to know how `radEmu` plays with `phyloseq` objects! One version of inputs to `emuFit` are 
 
   - `formula`: This is a formula telling radEmu what predictors to use in its model. We are using Group, which is an indicator for case (CRC) vs control (CTR). 
@@ -136,7 +148,7 @@ and some optional arguments include
 ```{r}
 ch_fit <- emuFit(formula = ~ Group, 
                  data = wirbel_sample[ch_study_obs, ],
-                 Y = wirbel_otu[ch_study_obs, restricted_mOTU_names],
+                 Y = small_Y,
                  run_score_tests = FALSE) 
 ```
 Let's check out what this object looks like!

--- a/vignettes/intro_radEmu.Rmd
+++ b/vignettes/intro_radEmu.Rmd
@@ -162,9 +162,9 @@ The way to access estimated coefficients and confidence intervals from the model
 
 ```{r, fig.width= 7, fig.height = 4}
 ch_df <- ch_fit$coef %>%
-  mutate(Genus = mOTU_name_df %>% 
+  mutate(Genus = (mOTU_name_df %>% 
            filter(genus_name %in% chosen_genera) %>% 
-           pull(genus_name)) %>%
+           pull(genus_name))[-category_to_rm]) %>%
   # add genus name to output from emuFit
   mutate(cat_small = stringr::str_remove(paste0("mOTU_", 
                             stringr::str_split(category, 'mOTU_v2_', simplify = TRUE)[, 2]), 
@@ -204,7 +204,7 @@ two_robust_score_tests <- emuFit(formula = ~ Group,
                                  B = ch_fit,
                                  test_kj = data.frame(k = covariate_to_test, 
                                                       j = taxa_to_test), 
-                                 Y = as.matrix(wirbel_otu[ch_study_obs, restricted_mOTU_names]))
+                                 Y = small_Y)
 ```
 
 Let's take a look at the test output.
@@ -244,7 +244,7 @@ We could run robust score tests for every taxon in this analysis, but it will ta
 test_all <- emuFit(formula = ~ Group, 
                    data = wirbel_sample[ch_study_obs, ],
                    B = ch_fit,
-                   Y = wirbel_otu[ch_study_obs, restricted_mOTU_names],
+                   Y = small_Y,
                    run_score_tests = TRUE)
 ```
 

--- a/vignettes/intro_radEmu_with_phyloseq.Rmd
+++ b/vignettes/intro_radEmu_with_phyloseq.Rmd
@@ -106,8 +106,7 @@ head(phyloseq::tax_table(wirbel_phylo))
 `radEmu` is a package that can be used to estimate fold-differences in the abundance of microbial taxa between levels of a covariate. In this analysis, the covariate that we are primarily interested in is whether a sample is from a case of colorectal cancer or a control. We will make control ("CTR") the reference category: 
 
 ```{r, eval = phy}
-phyloseq::sample_data(wirbel_phylo)$Group <- factor(phyloseq::sample_data(wirbel_phylo)$Group, 
-                                                    levels = c("CTR","CRC"))
+phyloseq::sample_data(wirbel_phylo)$Group <- factor(phyloseq::sample_data(wirbel_phylo)$Group, levels = c("CTR","CRC"))
 ```
 
 While in general we would fit a model to all mOTUs, we are going to subset to some specific genera for the purposes of this tutorial. Let's look at *Eubacterium*, *Porphyromonas*, *Faecalibacteria*, and *Fusobacterium* for now.
@@ -121,6 +120,16 @@ Again, while we would generally fit a model using all of our samples, for this t
 
 ```{r, eval = phy}
 wirbel_china <- phyloseq::subset_samples(wirbel_restrict, Country == "CHI")
+```
+
+Next, we want to confirm that all samples have at least one non-zero count across the categories we've chosen and that all categories have at least one non-zero count across the samples we've chosen.
+
+```{r}
+sum(rowSums(phyloseq::otu_table(wirbel_china)) == 0) # no samples have a count sum of 0 
+sum(colSums(phyloseq::otu_table(wirbel_china)) == 0) # one category has a count sum of 0 
+category_to_rm <- names(which(colSums(phyloseq::otu_table(wirbel_china)) == 0))
+wirbel_china <- phyloseq::subset_taxa(wirbel_china, species != category_to_rm)
+sum(colSums(phyloseq::otu_table(wirbel_china)) == 0) # now no categories have a count sum of 0 
 ```
 
 The function that we use to fit our model is called `emuFit`. It can accept your data in various forms, and here we will show how to use it with a `phyloseq` object as input. 

--- a/vignettes/parallel_radEmu.Rmd
+++ b/vignettes/parallel_radEmu.Rmd
@@ -74,6 +74,15 @@ restricted_mOTU_names <- mOTU_name_df %>%
   pull(name)
 # pull out observations from a chinese study within the meta-analysis
 ch_study_obs <- which(wirbel_sample$Country %in% c("CHI"))
+# make count matrix for chosen samples and genera
+small_Y <- wirbel_otu[ch_study_obs, restricted_mOTU_names]
+# check for samples with only zero counts
+sum(rowSums(small_Y) == 0) # no samples have a count sum of 0 
+# check for genera with only zero counts
+sum(colSums(small_Y) == 0) # one category has a count sum of 0
+# remove the one genus with only zero counts
+category_to_rm <- which(colSums(small_Y) == 0)
+small_Y <- small_Y[, -category_to_rm]
 ```
 
 Now that we've processed our data, we can fit the `radEmu` model. Here we just want to get estimates for our parameters and their standard errors, but we will avoid running score tests by setting `run_score_tests = FALSE`.
@@ -81,7 +90,7 @@ Now that we've processed our data, we can fit the `radEmu` model. Here we just w
 ```{r}
 ch_fit <- emuFit(formula = ~ Group, 
                  data = wirbel_sample[ch_study_obs, ],
-                 Y = wirbel_otu[ch_study_obs, restricted_mOTU_names],
+                 Y = small_Y,
                  run_score_tests = FALSE) 
 ```
 
@@ -99,7 +108,7 @@ robust_score <- emuFit(formula = ~ Group,
                        refit = FALSE,
                        test_kj = data.frame(k = covariate_to_test, 
                                             j = mOTU_to_test), 
-                       Y = as.matrix(wirbel_otu[ch_study_obs, restricted_mOTU_names]))
+                       Y = small_Y)
 robust_score$coef$pval[mOTU_to_test]
 ```
 
@@ -126,7 +135,7 @@ emuTest <- function(category) {
                        refit = FALSE,
                        test_kj = data.frame(k = covariate_to_test, 
                                             j = category), 
-                       Y = as.matrix(wirbel_otu[ch_study_obs, restricted_mOTU_names]))
+                       Y = small_Y)
   return(score_res)
 }
 ```
@@ -150,8 +159,8 @@ Now, we can see that this barely took more time than running a single score test
 
 ```{r}
 if (!is.null(score_res)) {
-  score_res[[1]]$coef$pval[1] ## robust score test p-value for the first taxon
-  score_res[[2]]$coef$pval[2] ## robust score test p-value for the second taxon
+  c(score_res[[1]]$coef$pval[1], ## robust score test p-value for the first taxon
+  score_res[[2]]$coef$pval[2]) ## robust score test p-value for the second taxon
 }
 ```
 


### PR DESCRIPTION
add check to `emuFit()` to throw an error if any columns of `Y` (representing categories) have 0 counts for all samples. Add test of this functionality.

Files that are changed:

- "emuFit.R" now adds this check and throws an error if needed
- "test-emuFit.R" now has a test of this functionality 