### PR TITLE
Add z_hat nuisance parameters to output

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -80,16 +80,18 @@
 #' p-value to be used should be chosen before conducting tests.
 #' 
 #' @return A list containing elements 'coef', 'B', 'penalized', 'Y_augmented',
-#' 'I', 'Dy', and 'score_test_hyperparams' if score tests are run.  Parameter estimates by 
-#' covariate and outcome category (e.g., taxon for microbiome data), as well as 
-#' optionally confidence intervals and p-values, are contained in 'coef'. 'B' 
-#' contains parameter estimates in matrix format (rows indexing covariates and 
-#' columns indexing outcome category / taxon). 'penalized' is equal to TRUE 
-#' if Firth penalty is used in estimation (default) and FALSE otherwise. 'I' and 
-#' 'Dy' contain an information matrix and empirical score covariance matrix 
-#' computed under the full model. 'score_test_hyperparams' contains parameters and 
-#' hyperparameters related to estimation under the null, including whether or not the 
-#' algorithm converged, which can be helpful for debugging. 
+#' 'z_hat', 'I', 'Dy', and 'score_test_hyperparams' if score tests are run.  Parameter
+#' estimates by covariate and outcome category (e.g., taxon for microbiome data),
+#' as well as optionally confidence intervals and p-values, are contained in 'coef'.
+#' 'B' contains parameter estimates in matrix format (rows indexing covariates and
+#' columns indexing outcome category / taxon). 'penalized' is equal to TRUE
+#' if Firth penalty is used in estimation (default) and FALSE otherwise. 'z_hat'
+#' returns the nuisance parameters calculated in Equation 7 of the radEmu manuscript,
+#' corresponding to either 'Y_augmented' or 'Y' if the 'penalized' is equal to TRUE
+#' or FALSE, respectively. 'I' and 'Dy' contain an information matrix and empirical
+#' score covariance matrix computed under the full model. 'score_test_hyperparams'
+#' contains parameters and hyperparameters related to estimation under the null,
+#' including whether or not the algorithm converged, which can be helpful for debugging. 
 #'
 #' @importFrom stats cov median model.matrix optim pchisq qnorm weighted.mean
 #' @import Matrix
@@ -603,8 +605,7 @@ and the corresponding gradient function to constraint_grad_fn.")
   if (penalize) {
     z_hat <- log(rowSums(Y_augmented)) - log(rowSums(exp(X %*% B)))
   } else {
-    # set z_hat to NUll because without penalty there is no Y augmentation
-    z_hat <- NULL
+    z_hat <- log(rowSums(Y)) - log(rowSums(exp(X %*% B)))
   }
   
   if (is.null(just_wald_things)) {

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -600,6 +600,13 @@ and the corresponding gradient function to constraint_grad_fn.")
     }
   }
   
+  if (penalize) {
+    z_hat <- log(rowSums(Y_augmented)) - log(rowSums(exp(X %*% B)))
+  } else {
+    # set z_hat to NUll because without penalty there is no Y augmentation
+    z_hat <- NULL
+  }
+  
   if (is.null(just_wald_things)) {
     I <- NULL
     Dy <- NULL
@@ -621,6 +628,7 @@ and the corresponding gradient function to constraint_grad_fn.")
                   "B" = B,
                   "penalized" = penalize,
                   "Y_augmented" = Y_augmented,
+                  "z_hat" = z_hat,
                   "I" = I,
                   "Dy" = Dy,
                   "cluster" = cluster)

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -574,3 +574,35 @@ test_that("emuFit throws error when there is a category with all zero counts", {
                            run_score_tests = FALSE)
   }) 
 })
+
+test_that("Confirm zi is provided only when model is penalized", {
+  
+  fitted_model1 <- emuFit(Y = Y,
+                          X = X,
+                          formula = ~group,
+                          data = covariates,
+                          verbose = FALSE,
+                          B_null_tol = 1e-2,
+                          tolerance = 0.01,
+                          tau = 2,
+                          return_wald_p = FALSE,
+                          compute_cis = FALSE,
+                          run_score_tests = FALSE)
+  
+  fitted_model2 <- emuFit(Y = Y,
+                          X = X,
+                          formula = ~group,
+                          data = covariates,
+                          verbose = FALSE,
+                          penalize = FALSE,
+                          B_null_tol = 1e-2,
+                          tolerance = 0.01,
+                          tau = 2,
+                          return_wald_p = FALSE,
+                          compute_cis = FALSE,
+                          run_score_tests = FALSE)
+  
+  expect_true(!is.null(fitted_model1$z_hat))
+  
+  expect_true(is.null(fitted_model2$z_hat))
+})

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -575,34 +575,34 @@ test_that("emuFit throws error when there is a category with all zero counts", {
   }) 
 })
 
-test_that("Confirm zi is provided only when model is penalized", {
+test_that("Confirm zi is different when penalty is applied or not", {
   
-  fitted_model1 <- emuFit(Y = Y,
-                          X = X,
-                          formula = ~group,
-                          data = covariates,
-                          verbose = FALSE,
-                          B_null_tol = 1e-2,
-                          tolerance = 0.01,
-                          tau = 2,
-                          return_wald_p = FALSE,
-                          compute_cis = FALSE,
-                          run_score_tests = FALSE)
+  fit_penT <- emuFit(Y = Y,
+                     X = X,
+                     formula = ~group,
+                     data = covariates,
+                     verbose = FALSE,
+                     penalize = TRUE,
+                     B_null_tol = 1e-2,
+                     tolerance = 0.01,
+                     tau = 2,
+                     return_wald_p = FALSE,
+                     compute_cis = FALSE,
+                     run_score_tests = FALSE)
   
-  fitted_model2 <- emuFit(Y = Y,
-                          X = X,
-                          formula = ~group,
-                          data = covariates,
-                          verbose = FALSE,
-                          penalize = FALSE,
-                          B_null_tol = 1e-2,
-                          tolerance = 0.01,
-                          tau = 2,
-                          return_wald_p = FALSE,
-                          compute_cis = FALSE,
-                          run_score_tests = FALSE)
+  fit_penF <- emuFit(Y = Y,
+                     X = X,
+                     formula = ~group,
+                     data = covariates,
+                     verbose = FALSE,
+                     penalize = FALSE,
+                     B_null_tol = 1e-2,
+                     tolerance = 0.01,
+                     tau = 2,
+                     return_wald_p = FALSE,
+                     compute_cis = FALSE,
+                     run_score_tests = FALSE)
   
-  expect_true(!is.null(fitted_model1$z_hat))
-  
-  expect_true(is.null(fitted_model2$z_hat))
+  expect_false(isTRUE(all.equal(fit_penT$z_hat,
+                                fit_penF$z_hat)))
 })


### PR DESCRIPTION
This commit addresses enhancement in issue #67, wherein we can add the z_hat nuisance parameters to the output when we also have the augmented Y matrix available.