### PR TITLE
Address issue #65 by checking for zero-comparison parameters and adding a flag

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Depends:
     MASS,
     Matrix,
     methods,
+    dplyr,
     R (>= 2.10)
 Suggests: 
     testthat (>= 3.0.0),
@@ -24,7 +25,6 @@ Suggests:
     phyloseq,
     knitr,
     magrittr,
-    dplyr, 
     ggplot2, 
     stringr, 
     parallel,

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -85,7 +85,7 @@
 #' small p-values and are not thought to have scientifically interesting signals. We recommend removing them before analyzing data further. 
 #' If TRUE, all zero-comparison parameter p-values will be set to NA. If FALSE no zero-comparison parameter p-values will be set to NA.
 #' If a value between 0 and 1, all zero-comparison p-values below the value will be set to NA. 
-#' Default is \code{0.05}. 
+#' Default is \code{0.01}. 
 #' 
 #' @return A list containing elements 'coef', 'B', 'penalized', 'Y_augmented',
 #' 'z_hat', 'I', 'Dy', and 'score_test_hyperparams' if score tests are run.  
@@ -151,10 +151,7 @@ emuFit <- function(Y,
                    trackB = FALSE,
                    return_nullB = FALSE,
                    return_both_score_pvals = FALSE,
-                   remove_zero_comparison_pvals = 0.05
-                   
-                   
-) {
+                   remove_zero_comparison_pvals = 0.01) {
   
   # Record call
   call <- match.call(expand.dots = FALSE)

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -95,8 +95,9 @@
 #' If there are any zero-comparison parameters in the model, a column 'zero_comparison'
 #' is also included, which is TRUE for any parameters that compare the level of a categorical
 #' covariate to a reference level for a category with only zero counts for both the comparison
-#' level and the reference level. This check is currently only implemented for a single categorical 
-#' covariate.
+#' level and the reference level. This check is currently implemented for an arbitrary design matrix
+#' generated using the \code{formula} and \code{data} arguments, and for a design matrix with no more
+#' than one categorical covariate if the design matrix \code{X} is input directly.
 #' 'B' contains parameter estimates in matrix format (rows indexing covariates and
 #' columns indexing outcome category / taxon). 
 #' 'penalized' is equal to TRUE f Firth penalty is used in estimation (default) and FALSE otherwise. 

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -84,7 +84,7 @@
 #' a category in which the comparison level and reference level both have 0 counts in all samples. These parameters can have misleadingly 
 #' small p-values and are not thought to have scientifically interesting signals. We recommend removing them before analyzing data further. 
 #' If TRUE, all zero-comparison parameter p-values will be set to NA. If FALSE no zero-comparison parameter p-values will be set to NA.
-#' If a value between 0 and 1, all zero-comparison p-values below the quantile represented by the value will be set to NA. 
+#' If a value between 0 and 1, all zero-comparison p-values below the value will be set to NA. 
 #' Default is \code{0.05}. 
 #' 
 #' @return A list containing elements 'coef', 'B', 'penalized', 'Y_augmented',
@@ -672,7 +672,8 @@ and the corresponding gradient function to constraint_grad_fn.")
         if (remove_zero_comparison_pvals == TRUE) {
           coefficients[coefficients$zero_comparison, col] <- NA
         } else {
-          ind <- ifelse(is.na(coefficients[, col]), FALSE, coefficients[, col] <= remove_zero_comparison_pvals)
+          ind <- ifelse(is.na(coefficients[, col]), FALSE, 
+                        coefficients[, col] <= remove_zero_comparison_pvals & coefficients$zero_comparison)
           coefficients[ind, col] <- NA
         }
       }

--- a/R/zero_comparison_check.R
+++ b/R/zero_comparison_check.R
@@ -1,50 +1,117 @@
 # function to check for zero comparison parameters 
 zero_comparison_check <- function(X, Y) {
   
-  # remove intercept 
-  base_X <- X[, -1, drop = FALSE]
-  
-  # check if there are more than 1 columns left 
-  if (ncol(base_X) > 1) {
+  # X is a matrix from model.matrix and has "assign" attribute 
+  if ("assign" %in% names(attributes(X))) {
     
-    # check if there is a single categorical covariate 
-    # i.e. all rows add up to 0 or 1 
-    if (all(rowSums(base_X) %in% c(0, 1))) {
+    col_assign <- attr(X, "assign")
+    col_shared <- sapply(col_assign, function(x) {sum(col_assign == x)})
+    col_kept <- col_assign[col_shared > 1]
+    
+    if (max(col_shared) > 1) {
       
-      # get indices for each group 
-      n_groups <- ncol(base_X) + 1
-      group_ind <- vector(mode = "list", length = n_groups)
-      group_ind[[1]] <- which(rowSums(base_X) == 0)
+      zero_comp_dat <- data.frame(covariate = NULL, category = NULL, 
+                                  zero_comparison = NULL)
       
-      for (i in 1:ncol(base_X)) {
-        group_ind[[i + 1]] <- which(base_X[, i] == 1)
+      cat_covs <- unique(col_kept)
+      for (col in cat_covs) {
+        base_X <- X[, col_assign == col]
+        
+        # get indices for each group 
+        n_groups <- ncol(base_X) + 1
+        group_ind <- vector(mode = "list", length = n_groups)
+        group_ind[[1]] <- which(rowSums(base_X) == 0)
+        
+        for (i in 1:ncol(base_X)) {
+          group_ind[[i + 1]] <- which(base_X[, i] == 1)
+        }
+        
+        # get Y sums for each group 
+        J <- ncol(Y)
+        group_counts <- matrix(NA, nrow = n_groups, ncol = J)
+        for (i in 1:n_groups) {
+          group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
+        }
+        
+        # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
+        zero_comp <- matrix(NA, nrow = n_groups - 1, J)
+        for (i in 1:(n_groups - 1)) {
+          zero_comp[i, ] <- (group_counts[1, ] == 0) * (group_counts[i + 1, ] == 0) == 1
+        }
+        
+        # if there are any zero-comparison parameters
+        if (sum(zero_comp) > 0) {
+          cov <- colnames(base_X)
+          cat <- colnames(Y)
+          new_zero_comp_dat <- data.frame(covariate = rep(cov, each = length(cat)),
+                                      category = rep(cat, length(cov)))
+          new_zero_comp_dat$zero_comparison <- as.vector(t(zero_comp))
+          zero_comp_dat <- rbind(zero_comp_dat, new_zero_comp_dat)
+        }
       }
-      
-      # get Y sums for each group 
-      J <- ncol(Y)
-      group_counts <- matrix(NA, nrow = n_groups, ncol = J)
-      for (i in 1:n_groups) {
-        group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
-      }
-      
-      # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
-      zero_comp <- matrix(NA, nrow = n_groups - 1, J)
-      for (i in 1:(n_groups - 1)) {
-        zero_comp[i, ] <- (group_counts[1, ] == 0) * (group_counts[i + 1, ] == 0) == 1
-      }
-      
-      # if there are any zero-comparison parameters
-      if (sum(zero_comp) > 0) {
-        cov <- colnames(base_X)
-        cat <- colnames(Y)
-        zero_comp_dat <- data.frame(covariate = rep(cov, each = length(cat)),
-                                    category = rep(cat, length(cov)))
-        zero_comp_dat$zero_comparison <- as.vector(t(zero_comp))
+      if (nrow(zero_comp_dat) > 0) {
         return(zero_comp_dat)
+      }
+    }
+  } else {
+  # X is a matrix (not from model matrix), need to check manually
+  # this will only identify a singular categorical covariate 
+    
+    # remove intercept 
+    base_X <- X[, -1, drop = FALSE]
+    
+    # remove any columns of X that include values other than 0 and 1 
+    non_cat_cols <- which(apply(base_X, 2, function(x) {sum(!(x %in% c(0, 1)))} > 0))
+    if (length(non_cat_cols) > 0 & length(non_cat_cols) == ncol(base_X)) {
+      return(NULL)
+    } else {
+      if (length(non_cat_cols) > 0) {
+        base_X <- base_X[, -non_cat_cols, drop = FALSE]
+      }
+    }
+    
+    # check if there are more than 1 columns left 
+    if (ncol(base_X) > 1) {
+      
+      # check if there is a single categorical covariate 
+      # i.e. all rows add up to 0 or 1 
+      if (all(rowSums(base_X) %in% c(0, 1))) {
+        
+        # get indices for each group 
+        n_groups <- ncol(base_X) + 1
+        group_ind <- vector(mode = "list", length = n_groups)
+        group_ind[[1]] <- which(rowSums(base_X) == 0)
+        
+        for (i in 1:ncol(base_X)) {
+          group_ind[[i + 1]] <- which(base_X[, i] == 1)
+        }
+        
+        # get Y sums for each group 
+        J <- ncol(Y)
+        group_counts <- matrix(NA, nrow = n_groups, ncol = J)
+        for (i in 1:n_groups) {
+          group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
+        }
+        
+        # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
+        zero_comp <- matrix(NA, nrow = n_groups - 1, J)
+        for (i in 1:(n_groups - 1)) {
+          zero_comp[i, ] <- (group_counts[1, ] == 0) * (group_counts[i + 1, ] == 0) == 1
+        }
+        
+        # if there are any zero-comparison parameters
+        if (sum(zero_comp) > 0) {
+          cov <- colnames(base_X)
+          cat <- colnames(Y)
+          zero_comp_dat <- data.frame(covariate = rep(cov, each = length(cat)),
+                                      category = rep(cat, length(cov)))
+          zero_comp_dat$zero_comparison <- as.vector(t(zero_comp))
+          return(zero_comp_dat)
+        }
+        
       }
       
     }
-    
   }
   
   # if there are no zero-comparison parameters, return NULL

--- a/R/zero_comparison_check.R
+++ b/R/zero_comparison_check.R
@@ -1,0 +1,53 @@
+# function to check for zero comparison parameters 
+zero_comparison_check <- function(X, Y) {
+  
+  # remove intercept 
+  base_X <- X[, -1, drop = FALSE]
+  
+  # check if there are more than 1 columns left 
+  if (ncol(base_X) > 1) {
+    
+    # check if there is a single categorical covariate 
+    # i.e. all rows add up to 0 or 1 
+    if (all(rowSums(base_X) %in% c(0, 1))) {
+      
+      # get indices for each group 
+      n_groups <- ncol(base_X) + 1
+      group_ind <- vector(mode = "list", length = n_groups)
+      group_ind[[1]] <- which(rowSums(base_X) == 0)
+      
+      for (i in 1:ncol(base_X)) {
+        group_ind[[i + 1]] <- which(base_X[, i] == 1)
+      }
+      
+      # get Y sums for each group 
+      J <- ncol(Y)
+      group_counts <- matrix(NA, nrow = n_groups, ncol = J)
+      for (i in 1:n_groups) {
+        group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
+      }
+      
+      # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
+      zero_comp <- matrix(NA, nrow = n_groups - 1, J)
+      for (i in 1:(n_groups - 1)) {
+        zero_comp[i, ] <- (group_counts[1, ] == 0) * (group_counts[i + 1, ] == 0) == 1
+      }
+      
+      # if there are any zero-comparison parameters
+      if (sum(zero_comp) > 0) {
+        cov <- colnames(base_X)
+        cat <- colnames(Y)
+        zero_comp_dat <- data.frame(covariate = rep(cov, each = length(cat)),
+                                    category = rep(cat, length(cov)))
+        zero_comp_dat$zero_comparison <- as.vector(t(zero_comp))
+        return(zero_comp_dat)
+      }
+      
+    }
+    
+  }
+  
+  # if there are no zero-comparison parameters, return NULL
+  return(NULL)
+  
+}

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -179,8 +179,9 @@ Any robust score statistics and score test p-values are also included in 'coef'.
 If there are any zero-comparison parameters in the model, a column 'zero_comparison'
 is also included, which is TRUE for any parameters that compare the level of a categorical
 covariate to a reference level for a category with only zero counts for both the comparison
-level and the reference level. This check is currently only implemented for a single categorical
-covariate.
+level and the reference level. This check is currently implemented for an arbitrary design matrix
+generated using the \code{formula} and \code{data} arguments, and for a design matrix with no more
+than one categorical covariate if the design matrix \code{X} is input directly.
 'B' contains parameter estimates in matrix format (rows indexing covariates and
 columns indexing outcome category / taxon).
 'penalized' is equal to TRUE f Firth penalty is used in estimation (default) and FALSE otherwise.

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -167,7 +167,7 @@ for categorical covariates with three or more levels, and represent parameters t
 a category in which the comparison level and reference level both have 0 counts in all samples. These parameters can have misleadingly
 small p-values and are not thought to have scientifically interesting signals. We recommend removing them before analyzing data further.
 If TRUE, all zero-comparison parameter p-values will be set to NA. If FALSE no zero-comparison parameter p-values will be set to NA.
-If a value between 0 and 1, all zero-comparison p-values below the quantile represented by the value will be set to NA.
+If a value between 0 and 1, all zero-comparison p-values below the value will be set to NA.
 Default is \code{0.05}.}
 }
 \value{

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -41,7 +41,8 @@ emuFit(
   max_step = 1,
   trackB = FALSE,
   return_nullB = FALSE,
-  return_both_score_pvals = FALSE
+  return_both_score_pvals = FALSE,
+  remove_zero_comparison_pvals = 0.05
 )
 }
 \arguments{
@@ -160,20 +161,35 @@ iterations and be returned? Primarily used for debugging. Default is FALSE.}
 information matrix computed from full model fit and from null model fits? Default is
 FALSE. This parameter is used for simulations - in any applied analysis, type of
 p-value to be used should be chosen before conducting tests.}
+
+\item{remove_zero_comparison_pvals}{Should score p-values be replaced with NA for zero-comparison parameters? These parameters occur
+for categorical covariates with three or more levels, and represent parameters that compare a covariate level to the reference level for
+a category in which the comparison level and reference level both have 0 counts in all samples. These parameters can have misleadingly
+small p-values and are not thought to have scientifically interesting signals. We recommend removing them before analyzing data further.
+If TRUE, all zero-comparison parameter p-values will be set to NA. If FALSE no zero-comparison parameter p-values will be set to NA.
+If a value between 0 and 1, all zero-comparison p-values below the quantile represented by the value will be set to NA.
+Default is \code{0.05}.}
 }
 \value{
 A list containing elements 'coef', 'B', 'penalized', 'Y_augmented',
-'z_hat', 'I', 'Dy', and 'score_test_hyperparams' if score tests are run.  Parameter
-estimates by covariate and outcome category (e.g., taxon for microbiome data),
+'z_hat', 'I', 'Dy', and 'score_test_hyperparams' if score tests are run.
+Parameter estimates by covariate and outcome category (e.g., taxon for microbiome data),
 as well as optionally confidence intervals and p-values, are contained in 'coef'.
+Any robust score statistics and score test p-values are also included in 'coef'.
+If there are any zero-comparison parameters in the model, a column 'zero_comparison'
+is also included, which is TRUE for any parameters that compare the level of a categorical
+covariate to a reference level for a category with only zero counts for both the comparison
+level and the reference level. This check is currently only implemented for a single categorical
+covariate.
 'B' contains parameter estimates in matrix format (rows indexing covariates and
-columns indexing outcome category / taxon). 'penalized' is equal to TRUE
-if Firth penalty is used in estimation (default) and FALSE otherwise. 'z_hat'
-returns the nuisance parameters calculated in Equation 7 of the radEmu manuscript,
+columns indexing outcome category / taxon).
+'penalized' is equal to TRUE f Firth penalty is used in estimation (default) and FALSE otherwise.
+'z_hat' returns the nuisance parameters calculated in Equation 7 of the radEmu manuscript,
 corresponding to either 'Y_augmented' or 'Y' if the 'penalized' is equal to TRUE
-or FALSE, respectively. 'I' and 'Dy' contain an information matrix and empirical
-score covariance matrix computed under the full model. 'score_test_hyperparams'
-contains parameters and hyperparameters related to estimation under the null,
+or FALSE, respectively.
+I' and 'Dy' contain an information matrix and empirical score covariance matrix computed under the
+full model.
+'score_test_hyperparams' contains parameters and hyperparameters related to estimation under the null,
 including whether or not the algorithm converged, which can be helpful for debugging.
 }
 \description{

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -42,7 +42,7 @@ emuFit(
   trackB = FALSE,
   return_nullB = FALSE,
   return_both_score_pvals = FALSE,
-  remove_zero_comparison_pvals = 0.05
+  remove_zero_comparison_pvals = 0.01
 )
 }
 \arguments{
@@ -168,7 +168,7 @@ a category in which the comparison level and reference level both have 0 counts 
 small p-values and are not thought to have scientifically interesting signals. We recommend removing them before analyzing data further.
 If TRUE, all zero-comparison parameter p-values will be set to NA. If FALSE no zero-comparison parameter p-values will be set to NA.
 If a value between 0 and 1, all zero-comparison p-values below the value will be set to NA.
-Default is \code{0.05}.}
+Default is \code{0.01}.}
 }
 \value{
 A list containing elements 'coef', 'B', 'penalized', 'Y_augmented',

--- a/tests/testthat/test-zero_comparison_check.R
+++ b/tests/testthat/test-zero_comparison_check.R
@@ -1,0 +1,57 @@
+dat <- data.frame(cov1 = rep(c("A", "B", "C"), each = 6),
+                  cov2 = rep(c("D", "E"), each = 9))
+form1 <- ~cov1
+form2 <- ~cov2
+X1 <- model.matrix(form1, dat)
+X2 <- model.matrix(form2, dat)
+Y <- matrix(rpois(18*6, 3), nrow = 18, ncol = 6)
+colnames(Y) <- paste0("category_", 1:ncol(Y))
+Y0 <- Y
+Y0[, c(1, 4)] <- 0
+Y0[15, 1] <- 2
+Y0[10, 4] <- 3
+
+test_that("zero_comparison_check function works", {
+
+  zero_comparison_res <- zero_comparison_check(X = X1, Y = Y0)
+  expect_true(zero_comparison_res$zero_comparison[1])
+  expect_true(zero_comparison_res$zero_comparison[10])
+  expect_false(zero_comparison_res$zero_comparison[2])
+  
+})
+
+test_that("zero_comparison column is added to coef when it should be", {
+  
+  # column doesn't exist with a 2 level covariate 
+  emuRes1 <- emuFit(Y = Y0, X = X2, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_false("zero_comparison" %in% names(emuRes1$coef))
+  
+  # column doesn't exist when no zero-comparison parameters 
+  emuRes2 <- emuFit(Y = Y, X = X1, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_false("zero_comparison" %in% names(emuRes2$coef))
+  
+  # column does exist when there are zero-comparison parameters
+  emuRes3 <- emuFit(Y = Y0, X = X1, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_true("zero_comparison" %in% names(emuRes3$coef))
+})
+
+test_that("remove_zero_comparison_pvals argument works in different ways", {
+  
+  expect_error(emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = 15))
+  
+  emuRes1 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = TRUE,
+                    test_kj = data.frame(k = 2, j = 1))
+  expect_true(is.na(emuRes1$coef$pval[1]))
+  emuRes2 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = TRUE,
+                    test_kj = data.frame(k = 2, j = 1), use_fullmodel_info = TRUE,
+                    return_both_score_pvals = TRUE)
+  expect_true(is.na(emuRes2$coef$score_pval_full_info[1]) &  
+                is.na(emuRes2$coef$score_pval_null_info[1]))
+  emuRes3 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = 0.5,
+                    test_kj = data.frame(k = 2, j = 1))
+  expect_true(is.na(emuRes3$coef$pval[1]) || emuRes3$coef$pval[1] > 0.5)
+  emuRes4 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = FALSE,
+                    test_kj = data.frame(k = 2, j = 1))
+  expect_true(emuRes4$coef$zero_comparison[1] & !is.na(emuRes4$coef$pval[1]))
+  
+})

--- a/tests/testthat/test-zero_comparison_check.R
+++ b/tests/testthat/test-zero_comparison_check.R
@@ -1,9 +1,26 @@
 dat <- data.frame(cov1 = rep(c("A", "B", "C"), each = 6),
-                  cov2 = rep(c("D", "E"), each = 9))
-form1 <- ~cov1
-form2 <- ~cov2
+                  cov2 = rep(c("D", "E"), each = 9),
+                  cov3 = rnorm(18),
+                  cov4 = rnorm(18),
+                  cov5 <- rep(c("G", "H", "I"), 6))
+form1 <- ~ cov1
+form2 <- ~ cov2
+form3 <- ~ cov1 + cov3
+form4 <- ~ cov1 + cov3 + cov4
+form5 <- ~ cov1 + cov2 + cov3 + cov4 + cov5
 X1 <- model.matrix(form1, dat)
+X1_base <- matrix(as.vector(X1), nrow = nrow(X1))
+colnames(X1_base) <- colnames(X1)
 X2 <- model.matrix(form2, dat)
+X2_base <- matrix(as.vector(X2), nrow = nrow(X2))
+colnames(X2_base) <- colnames(X2)
+X3 <- model.matrix(form3, dat)
+X3_base <- matrix(as.vector(X3), nrow = nrow(X3))
+colnames(X3_base) <- colnames(X3)
+X4 <- model.matrix(form4, dat)
+X4_base <- matrix(as.vector(X4), nrow = nrow(X4))
+colnames(X4_base) <- colnames(X4)
+X5 <- model.matrix(form5, dat)
 Y <- matrix(rpois(18*6, 3), nrow = 18, ncol = 6)
 colnames(Y) <- paste0("category_", 1:ncol(Y))
 Y0 <- Y
@@ -11,9 +28,10 @@ Y0[, c(1, 4)] <- 0
 Y0[15, 1] <- 2
 Y0[10, 4] <- 3
 
+### check functionality when X does not have "assign" attribute from `model.matrix`
 test_that("zero_comparison_check function works", {
 
-  zero_comparison_res <- zero_comparison_check(X = X1, Y = Y0)
+  zero_comparison_res <- zero_comparison_check(X = X1_base, Y = Y0)
   expect_true(zero_comparison_res$zero_comparison[1])
   expect_true(zero_comparison_res$zero_comparison[10])
   expect_false(zero_comparison_res$zero_comparison[2])
@@ -21,6 +39,49 @@ test_that("zero_comparison_check function works", {
 })
 
 test_that("zero_comparison column is added to coef when it should be", {
+  
+  # column doesn't exist with a 2 level covariate 
+  emuRes1 <- emuFit(Y = Y0, X = X2_base, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_false("zero_comparison" %in% names(emuRes1$coef))
+  
+  # column doesn't exist when no zero-comparison parameters 
+  emuRes2 <- emuFit(Y = Y, X = X1_base, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_false("zero_comparison" %in% names(emuRes2$coef))
+  
+  # column does exist when there are zero-comparison parameters
+  emuRes3 <- emuFit(Y = Y0, X = X1_base, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_true("zero_comparison" %in% names(emuRes3$coef))
+  
+  # column does exist in the presence of continuous covariate 
+  emuRes4 <- emuFit(Y = Y0, X = X4_base, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_true("zero_comparison" %in% names(emuRes4$coef))
+  
+})
+
+test_that("remove_zero_comparison_pvals argument works in different ways", {
+  
+  expect_error(emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = 15))
+  
+  emuRes1 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = TRUE,
+                    test_kj = data.frame(k = 2, j = 1))
+  expect_true(is.na(emuRes1$coef$pval[1]))
+  emuRes2 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = TRUE,
+                    test_kj = data.frame(k = 2, j = 1), use_fullmodel_info = TRUE,
+                    return_both_score_pvals = TRUE)
+  expect_true(is.na(emuRes2$coef$score_pval_full_info[1]) &  
+                is.na(emuRes2$coef$score_pval_null_info[1]))
+  emuRes3 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = 0.5,
+                    test_kj = data.frame(k = 2, j = 1:2))
+  expect_true(is.na(emuRes3$coef$pval[1]) || emuRes3$coef$pval[1] > 0.5)
+  expect_false(is.na(emuRes3$coef$pval[2]))
+  emuRes4 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = FALSE,
+                    test_kj = data.frame(k = 2, j = 1))
+  expect_true(emuRes4$coef$zero_comparison[1] & !is.na(emuRes4$coef$pval[1]))
+  
+})
+
+### check functionality when X does have "assign" attribute from `model.matrix`
+test_that("zero_comparison column is added to coef when it should be, model.matrix X", {
   
   # column doesn't exist with a 2 level covariate 
   emuRes1 <- emuFit(Y = Y0, X = X2, run_score_tests = FALSE, compute_cis = FALSE)
@@ -33,26 +94,16 @@ test_that("zero_comparison column is added to coef when it should be", {
   # column does exist when there are zero-comparison parameters
   emuRes3 <- emuFit(Y = Y0, X = X1, run_score_tests = FALSE, compute_cis = FALSE)
   expect_true("zero_comparison" %in% names(emuRes3$coef))
-})
-
-test_that("remove_zero_comparison_pvals argument works in different ways", {
   
-  expect_error(emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = 15))
+  # column does exist in the presence of continuous covariate 
+  emuRes4 <- emuFit(Y = Y0, X = X4, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_true("zero_comparison" %in% names(emuRes4$coef))
   
-  emuRes1 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = TRUE,
-                    test_kj = data.frame(k = 2, j = 1))
-  expect_true(is.na(emuRes1$coef$pval[1]))
-  emuRes2 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = TRUE,
-                    test_kj = data.frame(k = 2, j = 1), use_fullmodel_info = TRUE,
-                    return_both_score_pvals = TRUE)
-  expect_true(is.na(emuRes2$coef$score_pval_full_info[1]) &  
-                is.na(emuRes2$coef$score_pval_null_info[1]))
-  emuRes3 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = 0.5,
-                    test_kj = data.frame(k = 2, j = 1:2))
-  expect_true(is.na(emuRes3$coef$pval[1]) || emuRes3$coef$pval[1] > 0.5)
-  expect_false(is.na(emuRes3$coef$pval[2]))
-  emuRes4 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = FALSE,
-                    test_kj = data.frame(k = 2, j = 1))
-  expect_true(emuRes4$coef$zero_comparison[1] & !is.na(emuRes4$coef$pval[1]))
-  
+  # column does exist when there are multiple category covariates 
+  emuRes5 <- emuFit(Y = Y0, X = X5, run_score_tests = FALSE, compute_cis = FALSE)
+  expect_true("zero_comparison" %in% names(emuRes5$coef))
+  expect_true(emuRes5$coef$zero_comparison[1])
+  expect_true(is.na(emuRes5$coef$zero_comparison[13]))
+  expect_true(emuRes5$coef$zero_comparison[31])
+  expect_false(emuRes5$coef$zero_comparison[32])
 })

--- a/tests/testthat/test-zero_comparison_check.R
+++ b/tests/testthat/test-zero_comparison_check.R
@@ -48,8 +48,9 @@ test_that("remove_zero_comparison_pvals argument works in different ways", {
   expect_true(is.na(emuRes2$coef$score_pval_full_info[1]) &  
                 is.na(emuRes2$coef$score_pval_null_info[1]))
   emuRes3 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = 0.5,
-                    test_kj = data.frame(k = 2, j = 1))
+                    test_kj = data.frame(k = 2, j = 1:2))
   expect_true(is.na(emuRes3$coef$pval[1]) || emuRes3$coef$pval[1] > 0.5)
+  expect_false(is.na(emuRes3$coef$pval[2]))
   emuRes4 <- emuFit(Y = Y0, X = X1, remove_zero_comparison_pvals = FALSE,
                     test_kj = data.frame(k = 2, j = 1))
   expect_true(emuRes4$coef$zero_comparison[1] & !is.na(emuRes4$coef$pval[1]))


### PR DESCRIPTION
This PR addresses issue #65, which notes that sometimes we observe surprisingly small p-values in the "scientifically no signal" setting of having a categorical covariate with three or more levels, and testing a parameter that compares a covariate level to a reference level for a category in which both the comparison level and the reference level only have 0 counts for all samples. This PR does the following (so far in the limited setting when the model is fit with a single covariate):

- adds the function `zero_comparison_check()` which in the setting of a single categorical covariate with three or more levels, checks for these zero-comparison parameters, and if any are found produces a data.frame with covariate names, category names, and whether or not each parameter is a zero-comparison parameter
- calls `zero_comparison_check()` from `emuFit()` to check for these parameters, and if any exist, adds a column to the `coef` data frame that is returned called "zero_comparison" with this information
- adds the argument `remove_zero_comparison_pvals` to `emuFit()`, which can either be `TRUE` in which case all score test p-values associated with zero-comparison parameters are set to `NA`, `FALSE`, in which case no score test p-values associated with zero-comparison parameters are set to `NA`, or a value between 0 and 1, in which case all score test p-values from zero-comparison parameters that are less than the value are set to `NA`. Implements the results of this argument to all score test p-values returned in `coef` 
- tests these new functionalities in the file "test-zero_comparison_check.R" 

to-do: update this functionality to apply to an arbitrary design matrix, with any number of covariates 