### PR TITLE
Matching row names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Depends: 
     MASS,
     Matrix,

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -225,16 +225,16 @@ covariates in formula must be provided.")
     if (nrow(X) == nrow(Y)){
       if(match_row_names){
         if(is.null(rownames(X))){
-          message("Row names are missing from the covariate matrix X. Assuming a one-to-one correspondence with the rows of the response matrix Y. Please double-check your data to confirm this correspondence.")
+          message("Row names are missing from the covariate matrix X. We will assume the rows are in the same order as in the response matrix Y. You are responsible for ensuring the order of your observations is the same in both matrices.")
         } else {
-          message("Row names are missing from the response matrix Y. Assuming a one-to-one correspondence with the rows of the covariate matrix X. Please double-check your data to confirm this correspondence.")
+          message("Row names are missing from the response matrix Y. We will assume the rows are in the same order as in the covariate matrix X. You are responsible for ensuring the order of your observations is the same in both matrices.")
         }
       }
     } else {
       if(is.null(rownames(X))){
-        stop("Row names are missing from the covariate matrix X, and the number of rows does not match the number of rows in the response matrix Y. Please check your data to resolve this inconsistency.")
+        stop("Row names are missing from the covariate matrix X, and the number of rows does not match the number of rows in the response matrix Y. Please resolve this issue before refitting the model.")
       } else {
-        stop("Row names are missing from the response matrix Y, and the number of rows does not match the number of rows in the covariate matrix X. Please check your data to resolve this inconsistency.")
+        stop("Row names are missing from the response matrix Y, and the number of rows does not match the number of rows in the covariate matrix X. Please resolve this issue before refitting the model.")
       }
     }
   } else{
@@ -243,24 +243,25 @@ covariates in formula must be provided.")
       names_Y <- rownames(Y)
       
       #Checking if any row names are duplicated
-      if (any(duplicated(names_X))) stop("Covariate matrix X has duplicated row names. Please ensure all row names are unique.")
-      if (any(duplicated(names_Y))) stop("Response matrix Y has duplicated row names. Please ensure all row names are unique.")
+      if (any(duplicated(names_X))) stop("Covariate matrix X has duplicated row names. Please ensure all row names are unique before refitting the model.")
+      if (any(duplicated(names_Y))) stop("Response matrix Y has duplicated row names. Please ensure all row names are unique before refitting the model.")
       
       # Find common row names
       common_names <- intersect(names_X, names_Y)
       
       if (length(common_names) < length(names_X) || length(common_names) < length(names_Y)) {
-        warning(sprintf("Row names differ between the covariate matrix (X) and the response matrix (Y). Subsetting to common rows only, resulting in %d samples.", length(common_names))) 
+        warning(sprintf("According to the rownames, there are observations that are missing either in the covariate matrix (X) and/or the response matrix (Y). We will subset to common rows only, resulting in %d samples.", length(common_names))) 
         
         X <- X[common_names, , drop = FALSE]
         Y <- Y[common_names, , drop = FALSE]
+        
       } else if(all.equal(rownames(Y), rownames(X)) != TRUE){
         message("There is a different row ordering between the covariate matrix (X) and the response matrix (Y). Covariate data will be reordered to match response data.")
         X <- X[rownames(Y), , drop = FALSE]
       }
     } else {
       if(nrow(X) != nrow(Y)){
-        stop("The number of rows does not match between the covariate matrix (X) and the response matrix (Y), and subsetting/matching by row name has been disabled. Please check your data to resolve this inconsistency.")
+        stop("The number of rows does not match between the covariate matrix (X) and the response matrix (Y), and subsetting/matching by row name has been disabled. Please resolve this issue before refitting the model.")
       }
     }
   }

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -24,6 +24,7 @@ emuFit(
   use_fullmodel_info = FALSE,
   use_fullmodel_cov = FALSE,
   use_both_cov = FALSE,
+  match_row_names = TRUE,
   constraint_fn = pseudohuber_center,
   constraint_grad_fn = dpseudohuber_center_dx,
   constraint_param = 0.1,
@@ -102,6 +103,9 @@ recomputed for each null model fit for score testing.}
 \item{use_both_cov}{logical: should score tests be run using information and
 empirical score covariance evaluated both under the null and full models?
 Used in simulations}
+
+\item{match_row_names}{logical: Make sure rows on covariate data and response data correspond to
+the same sample by comparing row names and subsetting/reordering if necessary.}
 
 \item{constraint_fn}{function g defining a constraint on rows of B; g(B_k) = 0
 for rows k = 1, ..., p of B. Default function is a smoothed median (minimizer of

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -17,6 +17,10 @@ for(i in 1:n){
   }
 }
 
+#To ensure the messages about lack of row names do not show in the tests
+rownames(X) <- paste0("Sample_",1:12)
+rownames(Y) <- paste0("Sample_",1:12)
+
 # Y <- structure(c(534337, 0, 0, 0, 376, 41, 19, 103, 0, 0, 85, 0, 42794, 
 #                  0, 0, 0, 95, 0, 0, 15, 0, 0, 0, 26, 0, 149, 0, 0, 0, 0, 0, 211, 
 #                  0, 0, 0, 0, 0, 103, 0, 0, 0, 1372, 83, 337, 0, 0, 0, 0, 0, 53, 

--- a/tests/testthat/test-row_name_matching.R
+++ b/tests/testthat/test-row_name_matching.R
@@ -15,7 +15,7 @@ test_that("emuFit handles missing row names", {
   X1 <- matrix(X.based, nrow = 18)            # No row names
   
   expect_message(emuFit(Y = Y, X = X1), 
-                 "Row names are missing from the covariate matrix X. Assuming a one-to-one correspondence with the rows of the response matrix Y. Please double-check your data to confirm this correspondence.")
+                 "Row names are missing from the covariate matrix X. We will assume the rows are in the same order as in the response matrix Y. You are responsible for ensuring the order of your observations is the same in both matrices.")
 })
 
 test_that("emuFit throws error on duplicate row names", {
@@ -24,7 +24,7 @@ test_that("emuFit throws error on duplicate row names", {
   rownames(X2)[5] <- "sample_4" #Repeating one of the sample labels
   
   expect_error(emuFit(Y = Y, X = X2), 
-               "Covariate matrix X has duplicated row names. Please ensure all row names are unique.")
+               "Covariate matrix X has duplicated row names. Please ensure all row names are unique before refitting the model.")
 })
 
 test_that("emuFit subsets to common row names with warning", {
@@ -34,7 +34,7 @@ test_that("emuFit subsets to common row names with warning", {
   Y3 <- Y[c(1:2,5:18), , drop = FALSE]
   
   expect_warning(emuFit(Y = Y3, X = X3), 
-                 regexp = "Row names differ between the covariate matrix \\(X\\) and the response matrix \\(Y\\)\\. Subsetting to common rows only, resulting in [0-9]+ samples\\.")
+                 regexp = "According to the rownames, there are observations that are missing either in the covariate matrix \\(X\\) and/or the response matrix \\(Y\\)\\. We will subset to common rows only, resulting in [0-9]+ samples\\.")
 })
 
 test_that("emuFit reorders rows of X when", {
@@ -71,5 +71,5 @@ test_that("emuFit stops when match_row_names is FALSE, but nrow does not coincid
   X6 <- X6[(1:16), , drop = FALSE]
   
   expect_error(emuFit(Y = Y, X = X6, match_row_names = FALSE), 
-               "The number of rows does not match between the covariate matrix \\(X\\) and the response matrix \\(Y\\), and subsetting/matching by row name has been disabled\\. Please check your data to resolve this inconsistency\\.")
+               "The number of rows does not match between the covariate matrix \\(X\\) and the response matrix \\(Y\\), and subsetting/matching by row name has been disabled\\. Please resolve this issue before refitting the model\\.")
 })

--- a/tests/testthat/test-row_name_matching.R
+++ b/tests/testthat/test-row_name_matching.R
@@ -1,0 +1,58 @@
+dat <- data.frame(cov1 = rep(c("A", "B", "C"), each = 6),
+                  cov2 = rep(c("D", "E"), each = 9),
+                  cov3 = rnorm(18),
+                  cov4 = rnorm(18),
+                  cov5 <- rep(c("G", "H", "I"), 6))
+
+form <- ~ cov1 + cov2 + cov3 + cov4 + cov5
+X.based <- model.matrix(form, dat)
+
+Y <- matrix(rpois(18*6, 3), nrow = 18, ncol = 6)
+colnames(Y) <- paste0("category_", 1:ncol(Y))
+rownames(Y) <- paste0("sample_", 1:nrow(Y))
+
+test_that("emuFit handles missing row names", {
+  X1 <- matrix(X.based, nrow = 18)            # No row names
+  
+  expect_message(emuFit(Y = Y, X = X1), 
+                 "Row names are missing from the covariate matrix X. Assuming a one-to-one correspondence with the rows of the response matrix Y. Please double-check your data to confirm this correspondence.")
+})
+
+test_that("emuFit throws error on duplicate row names", {
+  X2 <- X.based
+  rownames(X2) <- rownames(Y)
+  rownames(X2)[5] <- "sample_4" #Repeating one of the sample labels
+  
+  expect_error(emuFit(Y = Y, X = X2), 
+               "Covariate matrix X has duplicated row names. Please ensure all row names are unique.")
+})
+
+test_that("emuFit subsets to common row names with warning", {
+  X3 <- X.based
+  rownames(X3) <- rownames(Y)
+  X3 <- X3[c(1:4,7:14,16:18),]
+  Y3 <- Y[c(1:2,5:18),]
+  
+  expect_warning(emuFit(Y = Y3, X = X3), 
+                 regexp = "Row names differ between the covariate matrix \\(X\\) and the response matrix \\(Y\\)\\. Subsetting to common rows only, resulting in [0-9]+ samples\\.")
+})
+
+#------
+
+test_that("emuFit reorders rows of X when", {
+  X <- matrix(1:9, nrow = 3, dimnames = list(c("B", "C", "A"), NULL))
+  Y <- matrix(9:1, nrow = 3, dimnames = list(c("A", "B", "C"), NULL))
+  
+  expect_warning(result <- MyFunc(X, Y, just_do_it = FALSE), 
+                 "Row names do not match in order")
+  expect_equal(rownames(result$X), rownames(result$Y))  # Ensure rows are reordered
+})
+
+test_that("MyFunc does not reorder rows of X when just_do_it is TRUE", {
+  X <- matrix(1:9, nrow = 3, dimnames = list(c("B", "C", "A"), NULL))
+  Y <- matrix(9:1, nrow = 3, dimnames = list(c("A", "B", "C"), NULL))
+  
+  result <- MyFunc(X, Y, just_do_it = TRUE)
+  expect_equal(rownames(result$X), c("B", "C", "A"))   # Original order maintained
+  expect_equal(rownames(result$Y), c("A", "B", "C"))
+})


### PR DESCRIPTION
This PR implements a process to ensure row names between covariate data and response data match when this information is available and provides helpful messages to the user indicating possible sources of inconsistencies, in order to address issue #94. The following checks are performed: 
**1.** If one or both matrices lack row names, but the number of rows is the same, then a one-to-one correspondence is assumed, but a message informing the user about this assumption is shown: "

> Row names are missing from (the matrix). Assuming a one-to-one correspondence with the rows of the (other matrix). Please double-check your data to confirm this correspondence."

 Message changes depending on which matrix is missing row names. 
If the number of rows does not coincide, an error message is printed instead: 

> "Row names are missing from the (matrix), and the number of rows does not match the number of rows in the (other matrix). Please check your data to resolve this inconsistency."

**2.** If both matrices have row names, then matching by row names is possible. A logical parameter `match_row_names` allows the user to disable this. 

**3.** If `match_row_names = TRUE` (default), we check first that no names are duplicated in any matrix (throwing an error message if we find duplicated names). Then, we subset to common row names with the following warning message if some row names did not coincide and thus were removed from the matrices 

> "Row names differ between the covariate matrix (X) and the response matrix (Y). Subsetting to common rows only, resulting in (number of rows preserved in both matrices) samples."

If all rows are common between the two matrices, but the order differs, we reorder X with the following message 

> There is a different row ordering between the covariate matrix (X) and the response matrix (Y). Covariate data will be reordered to match response data."

**4.** If `match_row_names = FALSE` we only check if the number of rows coincides between the two matrices, with the following error message if they do not

> "The number of rows does not match between the covariate matrix (X) and the response matrix (Y), and subsetting/matching by row name has been disabled. Please check your data to resolve this inconsistency."