### PR TITLE
Add timing to verbose

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -690,10 +690,10 @@ and the corresponding gradient function to constraint_grad_fn.")
         if (sec <= 300) {
           time <- paste0(sec, " seconds")
         } else if (sec <= 18000) {
-          min <- sec / 60
+          min <- round(sec / 60)
           time <- paste0(min, " minutes")
         } else {
-          hour <- sec / (60^2)
+          hour <- round(sec / (60^2))
           time <- paste0(hour, " hours")
         }
         message(paste("Score test ", test_ind, " of ", nrow(test_kj)," (row of B k = ", test_kj$k[test_ind], "; column of B j = ",

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -579,8 +579,9 @@ and the corresponding gradient function to constraint_grad_fn.")
     for(test_ind in 1:nrow(test_kj)) {
       
       if (verbose %in% c(TRUE, "development")) {
-        print(paste("Running score test ", test_ind, " of ", nrow(test_kj)," (row of B k = ", test_kj$k[test_ind], "; column of B j = ",
+        message(paste("Running score test ", test_ind, " of ", nrow(test_kj)," (row of B k = ", test_kj$k[test_ind], "; column of B j = ",
                     test_kj$j[test_ind],").",sep = ""))
+        start <- proc.time()
       }
       
       B_to_use <- fitted_B
@@ -681,6 +682,24 @@ and the corresponding gradient function to constraint_grad_fn.")
                                                                   lower.tail = FALSE)
         }
       
+      }
+      
+      if (verbose %in% c(TRUE, "development")) {
+        end <- proc.time() - start
+        sec <- round(end[3]) 
+        if (sec <= 300) {
+          time <- paste0(sec, " seconds")
+        } else if (sec <= 18000) {
+          min <- sec / 60
+          time <- paste0(min, " minutes")
+        } else {
+          hour <- sec / (60^2)
+          time <- paste0(hour, " hours")
+        }
+        message(paste("Score test ", test_ind, " of ", nrow(test_kj)," (row of B k = ", test_kj$k[test_ind], "; column of B j = ",
+                    test_kj$j[test_ind],") has completed in approximately ", time, ".",sep = ""))
+        start <- proc.time()
+        
       }
     }
   }

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -600,3 +600,20 @@ test_that("emuFit works with fitted objects passed in", {
   })
   
 })
+
+test_that("emuFit produces appropriate output when verbose = TRUE", {
+  
+  # check that when running score tests it tells you what is running and how long it has taken
+  messages <- capture_messages(fitted_model <- emuFit(Y = Y,
+                                                      X = X,
+                                                      formula = ~group,
+                                                      data = covariates,
+                                                      verbose = TRUE,
+                                                      B_null_tol = 1e-2,
+                                                      tolerance = 0.01,
+                                                      tau = 2,
+                                                      test_kj = data.frame(j = 1, k = 2)))
+  expect_true(TRUE %in% grepl("Running score test", messages) & 
+                TRUE %in% grepl("has completed in approximately", messages))
+  
+})


### PR DESCRIPTION
updating emuFit() when verbose = TRUE to not only report which test is running, but also report when it completes and how much time it took (either rounded to either seconds, minutes, or hours depending on how long it has been)