### PR TITLE
Make argument `test_kj` required in `emuFit()` when `run_score_tests = TRUE` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: radEmu
 Title: Using Relative Abundance Data to Estimate of Multiplicative Differences in Mean Absolute Abundance 
-Version: 1.2.0.0
+Version: 2.0.0.0
 Authors@R: as.person(c(
     "David Clausen <dsc24@uw.edu> [aut, cre]",
     "Amy Willis [aut]", 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: radEmu
 Title: Using Relative Abundance Data to Estimate of Multiplicative Differences in Mean Absolute Abundance 
 Version: 2.0.0.0
-Authors@R: c(person("David", "Clausen", role = c("aut", "cre")),
-             person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut"), comment = c(ORCID = "0000-0002-2802-4317")),
+Authors@R: c(person("David", "Clausen", role = c("aut")),
+             person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2802-4317")),
              person("Sarah", "Teichman", role = "aut"))
 Description: A differential abundance method for the analysis of microbiome data. radEmu estimates fold-differences in the abundance of taxa across samples relative to "typical" fold-differences. Notably, it does not require pseudocounts, nor choosing a denominator taxon. 
 URL: https://github.com/statdivlab/radEmu, https://statdivlab.github.io/radEmu/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,9 @@
 Package: radEmu
 Title: Using Relative Abundance Data to Estimate of Multiplicative Differences in Mean Absolute Abundance 
 Version: 2.0.0.0
-Authors@R: as.person(c(
-    "David Clausen [aut, cre]",
-    "Amy Willis <adwillis@uw.edu> [aut]", 
-    "Sarah Teichman [aut]"
-  ))
+Authors@R: c(person("David", "Clausen", role = c("aut", "cre")),
+             person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut"), comment = c(ORCID = "0000-0002-2802-4317")),
+             person("Sarah", "Teichman", role = "aut"))
 Description: A differential abundance method for the analysis of microbiome data. radEmu estimates fold-differences in the abundance of taxa across samples relative to "typical" fold-differences. Notably, it does not require pseudocounts, nor choosing a denominator taxon. 
 URL: https://github.com/statdivlab/radEmu, https://statdivlab.github.io/radEmu/
 License: MIT + file LICENSE

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,7 @@
+# radEmu 2.0.0.0
+
+This is a major release that updates the argument `test_kj` in the function `emuFit()` in a way that is not backwards compatible.
+
+## Breaking changes
+
+* When `emuFit()` is run with the default of `run_score_tests = TRUE`, the argument `test_kj` is now required instead of optional. In previous versions when`run_score_tests = TRUE` and `test_kj` was not included, score tests were run for all parameters in the model except for intercept parameters. As these score tests can be computationally expensive, we want to make sure that the user only runs tests for parameters that they want to include in the analysis. 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
 # radEmu 2.0.0.0
 
-This is a major release that updates the argument `test_kj` in the function `emuFit()` in a way that is not backwards compatible.
+This is a major release that speeds up score tests, and forces the user to clarify that they wish to perform score tests. It makes the default behaviour faster, but is not backwards compatible.
 
 ## Breaking changes
 
-* When `emuFit()` is run with the default of `run_score_tests = TRUE`, the argument `test_kj` is now required instead of optional. In previous versions when`run_score_tests = TRUE` and `test_kj` was not included, score tests were run for all parameters in the model except for intercept parameters. As these score tests can be computationally expensive, we want to make sure that the user only runs tests for parameters that they want to include in the analysis. 
+* The argument `test_kj` is now required for `emuFit()` when `run_score_tests = TRUE` (the default). Previous default behavior was to run score tests for every parameter, which can be very time consuming(and can easily be parallelized). This change forces the user to explicitly state what tests they would like to run, significantly decreasing unnecessary computation. 
+
+## Additional changes
+
+* We have also streamlined estimation under the null, leading to improved convergence and reduced computation. 

--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -22,11 +22,11 @@
 #' should fitting step be skipped (FALSE), e.g., if score tests are to be run on an already
 #' fitted model. Default is TRUE.
 #' @param test_kj a data frame whose rows give coordinates (in category j and
-#' covariate k) of elements of B to construct hypothesis tests for. If \code{test_kj}
-#' is not provided, all elements of B save the intercept row will be tested. If you don't know
+#' covariate k) of elements of B to construct hypothesis tests for. If you don't know
 #' which indices k correspond to the covariate(s) that you would like to test, run the function
 #' \code{radEmu::make_design_matrix()} in order to view the design matrix, and identify which
-#' column of the design matrix corresponds to each covariate in your model.
+#' column of the design matrix corresponds to each covariate in your model. This argument is required when
+#' running score tests.
 #' @param alpha nominal type 1 error level to be used to construct confidence intervals. Default is 0.05
 #' (corresponding to 95% confidence intervals)
 #' @param return_wald_p logical: return p-values from Wald tests? Default is FALSE.
@@ -207,7 +207,8 @@ emuFit <- function(Y,
                                 match_row_names = match_row_names,
                                 verbose = verbose,
                                 remove_zero_comparison_pvals = remove_zero_comparison_pvals,
-                                unobserved_taxon_error = unobserved_taxon_error)
+                                unobserved_taxon_error = unobserved_taxon_error,
+                                run_score_tests = run_score_tests)
   Y <- check_results$Y
   X <- check_results$X
   cluster <- check_results$cluster

--- a/R/emuFit_check.R
+++ b/R/emuFit_check.R
@@ -29,6 +29,7 @@
 #' If a value between 0 and 1, all zero-comparison p-values below the value will be set to NA. 
 #' Default is \code{0.01}. 
 #' @param unobserved_taxon_error logical: should an error be thrown if Y includes taxa that have 0 counts for all samples? Default is TRUE.
+#' @param run_score_tests logical: perform robust score testing? 
 #' 
 #' @return returns objects \code{Y}, \code{X}, \code{cluster}, and \code{B_null_list}, which may be modified by tests, and throw any useful
 #' errors, warnings, or messages.
@@ -46,7 +47,8 @@ emuFit_check <- function(Y,
                          match_row_names = TRUE,
                          verbose = FALSE,
                          remove_zero_comparison_pvals = 0.01,
-                         unobserved_taxon_error = TRUE) {
+                         unobserved_taxon_error = TRUE,
+                         run_score_tests = TRUE) {
   
   # confirm that input to verbose is valid
   if (!(verbose %in% c(FALSE, TRUE, "development"))) {
@@ -201,6 +203,13 @@ ignoring argument 'cluster'.")
       } else {
         stop("Make sure that the values of `j` in `test_kj` are numeric or correspond to column names of the `Y` matrix.")
       }
+    }
+  }
+  
+  # check that test_kj is not null if running score tests
+  if (run_score_tests) {
+    if (is.null(test_kj)) {
+      stop("When `run_score_tests = TRUE`, you must provide a matrix `test_kj` to determine which parameters you want to test. If you don't know which indices k correspond to the covariate(s) that you would like to test, run the function `radEmu::make_design_matrix()` in order to view the design matrix, and identify which column of the design matrix corresponds to each covariate in your model. If you don't know which indices j correspond to categories (taxa) that you want to test, you can look at the columns and column names of your `Y` matrix.")
     }
   }
   

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -83,11 +83,11 @@ should fitting step be skipped (FALSE), e.g., if score tests are to be run on an
 fitted model. Default is TRUE.}
 
 \item{test_kj}{a data frame whose rows give coordinates (in category j and
-covariate k) of elements of B to construct hypothesis tests for. If \code{test_kj}
-is not provided, all elements of B save the intercept row will be tested. If you don't know
+covariate k) of elements of B to construct hypothesis tests for. If you don't know
 which indices k correspond to the covariate(s) that you would like to test, run the function
 \code{radEmu::make_design_matrix()} in order to view the design matrix, and identify which
-column of the design matrix corresponds to each covariate in your model.}
+column of the design matrix corresponds to each covariate in your model. This argument is required when
+running score tests.}
 
 \item{alpha}{nominal type 1 error level to be used to construct confidence intervals. Default is 0.05
 (corresponding to 95\% confidence intervals)}

--- a/man/emuFit_check.Rd
+++ b/man/emuFit_check.Rd
@@ -16,7 +16,8 @@ emuFit_check(
   match_row_names = TRUE,
   verbose = FALSE,
   remove_zero_comparison_pvals = 0.01,
-  unobserved_taxon_error = TRUE
+  unobserved_taxon_error = TRUE,
+  run_score_tests = TRUE
 )
 }
 \arguments{
@@ -60,6 +61,8 @@ If a value between 0 and 1, all zero-comparison p-values below the value will be
 Default is \code{0.01}.}
 
 \item{unobserved_taxon_error}{logical: should an error be thrown if Y includes taxa that have 0 counts for all samples? Default is TRUE.}
+
+\item{run_score_tests}{logical: perform robust score testing?}
 }
 \value{
 returns objects \code{Y}, \code{X}, \code{cluster}, and \code{B_null_list}, which may be modified by tests, and throw any useful

--- a/tests/testthat/test-augmentation-failures.R
+++ b/tests/testthat/test-augmentation-failures.R
@@ -22,8 +22,10 @@ test_that("confirm Matrix Csparse_transpose issue is not happening", {
                          B_null_tol = 1e-2,
                          tolerance = 0.01,
                          tau = 2,
-                         run_score_test = TRUE,
-                         return_wald_p = TRUE)
+                         run_score_tests = TRUE,
+                         return_wald_p = TRUE,
+                         test_kj = data.frame(k = 2, j = 1),
+                         match_row_names = FALSE)
   
   expect_true("emuFit" %in% class(fitted_model))
   
@@ -37,8 +39,10 @@ test_that("confirm Matrix Csparse_transpose issue is not happening", {
                             B_null_tol = 1e-2,
                             tolerance = 0.01,
                             tau = 2,
-                            run_score_test = TRUE,
-                            return_wald_p = TRUE)
+                            run_score_tests = TRUE,
+                            return_wald_p = TRUE,
+                            test_kj = data.frame(k = 2, j = 1),
+                            match_row_names = FALSE)
   
   expect_true("emuFit" %in% class(fitted_model_df))
   

--- a/tests/testthat/test-cluster.R
+++ b/tests/testthat/test-cluster.R
@@ -23,7 +23,8 @@ test_that("clusters work as I want", {
                    data = XX, 
                    Y = Y, 
                    cluster=cage_num, 
-                   run_score_tests=FALSE) #### very fast
+                   run_score_tests=FALSE,
+                   match_row_names = FALSE) #### very fast
   expect_equal(ef_num$coef %>% class, "data.frame")
   
   # check that cluster argument works as character vector and gives 
@@ -33,7 +34,8 @@ test_that("clusters work as I want", {
                     data = XX, 
                     Y = Y, 
                     cluster=cage_char, 
-                    run_score_tests=FALSE) 
+                    run_score_tests=FALSE,
+                    match_row_names = FALSE) 
   expect_equal(ef_num$coef, ef_char$coef)
   
   # check that cluster argument works as factor and gives equivalent results
@@ -43,7 +45,8 @@ test_that("clusters work as I want", {
                     data = XX, 
                     Y = Y, 
                     cluster=cage_fact, 
-                    run_score_tests=FALSE) 
+                    run_score_tests=FALSE,
+                    match_row_names = FALSE) 
   expect_equal(ef_num$coef, ef_fact$coef)
 })
 
@@ -110,7 +113,8 @@ test_that("GEE with cluster covariance gives plausible type 1 error ",{
                                    return_both_score_pvals = FALSE,
                                    test_kj = data.frame(k = c(2,2),
                                                         j = c(3,4)),
-                                   cluster = cluster)
+                                   cluster = cluster,
+                                   match_row_names = FALSE)
     
     fitted_model_nocluster <- emuFit(Y = Y,
                                      X = X,
@@ -127,7 +131,8 @@ test_that("GEE with cluster covariance gives plausible type 1 error ",{
                                      use_fullmodel_cov = FALSE,
                                      return_both_score_pvals = FALSE,
                                      test_kj = data.frame(k = c(2,2),
-                                                          j = c(3,4)))
+                                                          j = c(3,4)),
+                                     match_row_names = FALSE)
     # })
     
     filtered_coef <- fitted_model_cluster$coef[!is.na(fitted_model_cluster$coef$pval),

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -39,7 +39,8 @@ test_that("emuFit takes formulas and actually fits a model", {
                            run_score_tests = TRUE, 
                            use_fullmodel_info = FALSE,
                            use_fullmodel_cov = FALSE,
-                           return_both_score_pvals = FALSE)
+                           return_both_score_pvals = FALSE,
+                           test_kj = data.frame(k = 2, j = 1:6))
   })
   
   
@@ -58,7 +59,7 @@ test_that("emuFit takes formulas and actually fits a model", {
                          formula = ~group,
                          data = covariates,
                          refit = FALSE,
-                         run_score_test = FALSE,
+                         run_score_tests= FALSE,
                          fitted_model = fitted_model)
   
   expect_identical(fitted_model$coef$estimate, second_model$coef$estimate)
@@ -72,10 +73,11 @@ test_that("emuFit takes formulas and actually fits a model", {
                                             B_null_tol = 0.01,
                                             tolerance = 0.01,
                                             data = covariates,
-                                            run_score_test = TRUE,
+                                            run_score_tests= TRUE,
                                             return_wald_p = TRUE, ### diff
                                             use_fullmodel_info = TRUE, ### diff
-                                            verbose = FALSE)
+                                            verbose = FALSE,
+                                            test_kj = data.frame(k = 2, j = 1:6))
   
   
   expect_true(all(fitted_model_use_fullmodel_info$coef$wald_p>0 & fitted_model_use_fullmodel_info$coef$wald_p<1))
@@ -92,11 +94,12 @@ test_that("emuFit takes formulas and actually fits a model", {
                                formula = ~group,
                                tau = 1.2,
                                data = covariates,
-                               run_score_test = TRUE,
+                               run_score_tests= TRUE,
                                return_wald_p = TRUE,
                                use_fullmodel_info = TRUE,
                                verbose = FALSE,
-                               return_both_score_pvals = TRUE)
+                               return_both_score_pvals = TRUE,
+                               test_kj = data.frame(k = 2, j = 1:6))
   
   ps_full <- fitted_model_both$coef$score_pval_full_info
   ps_null <- fitted_model_both$coef$score_pval_null_info
@@ -115,7 +118,7 @@ test_that("emuFit takes formulas and actually fits a model", {
   #                       formula = ~group,
   #                       tau = 1.2,
   #                       data = covariates,
-  #                       run_score_test = TRUE,
+  #                       run_score_tests= TRUE,
   #                       return_wald_p = TRUE,
   #                       use_fullmodel_info = TRUE,
   #                       verbose = FALSE,
@@ -146,7 +149,8 @@ test_that("emuFit takes cluster argument without breaking ",{
                                    use_fullmodel_info = FALSE,
                                    use_fullmodel_cov = FALSE,
                                    return_both_score_pvals = FALSE,
-                                   cluster = rep(1:3,each = 4))
+                                   cluster = rep(1:3,each = 4),
+                                   test_kj = data.frame(k = 2, j = 1:6))
           })
   
   expect_silent({
@@ -163,7 +167,8 @@ test_that("emuFit takes cluster argument without breaking ",{
                                    run_score_tests = TRUE, 
                                    use_fullmodel_info = FALSE,
                                    use_fullmodel_cov = FALSE,
-                                   return_both_score_pvals = FALSE)
+                                   return_both_score_pvals = FALSE,
+                                   test_kj = data.frame(k = 2, j = 1:6))
   })
   
   expect_true(all(fitted_model_nocluster$coef$estimate == fitted_model_cluster$coef$estimate))
@@ -336,7 +341,7 @@ test_that("GEE with cluster covariance gives plausible type 1 error ",{
 #            formula = ~group,
 #            data = covariates,
 #            tolerance = 0.01,
-#            run_score_test = FALSE,
+#            run_score_tests= FALSE,
 #            return_wald_p = TRUE)
 #   
 #   
@@ -364,7 +369,8 @@ test_that("emuFit runs without penalty", {
                            run_score_tests = TRUE, 
                            use_fullmodel_info = FALSE,
                            use_fullmodel_cov = FALSE,
-                           return_both_score_pvals = FALSE)
+                           return_both_score_pvals = FALSE,
+                           test_kj = data.frame(k = 2, j = 1:6))
   })
 })
 
@@ -383,7 +389,8 @@ test_that("emuFit runs with just intercept model", {
                            run_score_tests = TRUE, 
                            use_fullmodel_info = FALSE,
                            use_fullmodel_cov = FALSE,
-                           return_both_score_pvals = FALSE)
+                           return_both_score_pvals = FALSE,
+                           test_kj = data.frame(k = 1, j = 1:6))
   })
   
   expect_message({
@@ -398,7 +405,8 @@ test_that("emuFit runs with just intercept model", {
                            run_score_tests = TRUE, 
                            use_fullmodel_info = FALSE,
                            use_fullmodel_cov = FALSE,
-                           return_both_score_pvals = FALSE)
+                           return_both_score_pvals = FALSE,
+                           test_kj = data.frame(k = 1, j = 1:6))
   })
   
   expect_equal(fitted_model$coef[, 2:9], fitted_model1$coef[, 2:9])

--- a/tests/testthat/test-plot_emuFit.R
+++ b/tests/testthat/test-plot_emuFit.R
@@ -23,7 +23,8 @@ fitted_model <- emuFit(Y = Y,
                        run_score_tests = FALSE, 
                        use_fullmodel_info = FALSE,
                        use_fullmodel_cov = FALSE,
-                       return_both_score_pvals = FALSE)
+                       return_both_score_pvals = FALSE,
+                       match_row_names = FALSE)
 
 test_that("plot() returns data frame and plot", {
   plot_out <- plot(x = fitted_model)

--- a/tests/testthat/test-row_name_matching.R
+++ b/tests/testthat/test-row_name_matching.R
@@ -14,7 +14,7 @@ rownames(Y) <- paste0("sample_", 1:nrow(Y))
 test_that("emuFit handles missing row names", {
   X1 <- matrix(X.based, nrow = 18)            # No row names
   
-  expect_message(emuFit(Y = Y, X = X1), 
+  expect_message(emuFit(Y = Y, X = X1, run_score_tests = FALSE), 
                  "Row names are missing from the covariate matrix X. We will assume the rows are in the same order as in the response matrix Y. You are responsible for ensuring the order of your observations is the same in both matrices.")
 })
 
@@ -23,7 +23,7 @@ test_that("emuFit throws error on duplicate row names", {
   rownames(X2) <- rownames(Y)
   rownames(X2)[5] <- "sample_4" #Repeating one of the sample labels
   
-  expect_error(emuFit(Y = Y, X = X2), 
+  expect_error(emuFit(Y = Y, X = X2, run_score_tests = FALSE), 
                "Covariate matrix X has duplicated row names. Please ensure all row names are unique before refitting the model.")
 })
 
@@ -33,7 +33,7 @@ test_that("emuFit subsets to common row names with warning", {
   X3 <- X3[c(1:4,7:14,16:18), , drop = FALSE]
   Y3 <- Y[c(1:2,5:18), , drop = FALSE]
   
-  expect_warning(emuFit(Y = Y3, X = X3), 
+  expect_warning(emuFit(Y = Y3, X = X3, run_score_tests = FALSE), 
                  regexp = "According to the rownames, there are observations that are missing either in the covariate matrix \\(X\\) and/or the response matrix \\(Y\\)\\. We will subset to common rows only, resulting in [0-9]+ samples\\.")
 })
 
@@ -42,9 +42,9 @@ test_that("emuFit reorders rows of X when", {
   rownames(X4) <- rownames(Y)
   X4.p <- X4[c(1,(nrow(Y):2)), , drop = FALSE]
 
-  expect_message(model.p <- emuFit(Y = Y, X = X4.p), 
+  expect_message(model.p <- emuFit(Y = Y, X = X4.p, run_score_tests = FALSE), 
                  "There is a different row ordering between the covariate matrix \\(X\\) and the response matrix \\(Y\\)\\. Covariate data will be reordered to match response data\\.")
-  model.o <- emuFit(Y = Y, X = X4)
+  model.o <- emuFit(Y = Y, X = X4, run_score_tests = FALSE)
   expect_equal(model.o$coef$estimate, model.p$coef$estimate)
 })
 
@@ -54,11 +54,11 @@ test_that("emuFit does not reorder rows of X when match_row_names is FALSE", {
   rownames(X5) <- rownames(Y)
   rownames(X5.p) <- rownames(Y)[c(1,nrow(Y):2)]
   
-  model.o <- emuFit(Y = Y, X = X5)
-  model.p <- emuFit(Y = Y, X = X5.p, match_row_names = FALSE)
+  model.o <- emuFit(Y = Y, X = X5, run_score_tests = FALSE)
+  model.p <- emuFit(Y = Y, X = X5.p, match_row_names = FALSE, run_score_tests = FALSE)
   
-  expect_silent(model.o <- emuFit(Y = Y, X = X5))
-  expect_silent(model.p <- emuFit(Y = Y, X = X5.p, match_row_names = FALSE))
+  expect_silent(model.o <- emuFit(Y = Y, X = X5, run_score_tests = FALSE))
+  expect_silent(model.p <- emuFit(Y = Y, X = X5.p, match_row_names = FALSE, run_score_tests = FALSE))
   
   expect_equal(model.o$coef$estimate, model.p$coef$estimate)
 })
@@ -70,6 +70,6 @@ test_that("emuFit stops when match_row_names is FALSE, but nrow does not coincid
   X6 <- X6[c(1,(nrow(Y):2)),]
   X6 <- X6[(1:16), , drop = FALSE]
   
-  expect_error(emuFit(Y = Y, X = X6, match_row_names = FALSE), 
+  expect_error(emuFit(Y = Y, X = X6, match_row_names = FALSE, run_score_tests = FALSE), 
                "The number of rows does not match between the covariate matrix \\(X\\) and the response matrix \\(Y\\), and subsetting/matching by row name has been disabled\\. Please resolve this issue before refitting the model\\.")
 })

--- a/tests/testthat/test-score_test.R
+++ b/tests/testthat/test-score_test.R
@@ -36,7 +36,8 @@ we do *not* get same results if we use incorrect info", {
                        B = NULL,
                        tolerance = 0.01,
                        verbose = FALSE,
-                       run_score_tests = FALSE)
+                       run_score_tests = FALSE,
+                       match_row_names = FALSE)
 
 
     B <- full_fit$B

--- a/tests/testthat/test-zero_comparison_check.R
+++ b/tests/testthat/test-zero_comparison_check.R
@@ -41,41 +41,50 @@ test_that("zero_comparison_check function works", {
 test_that("zero_comparison column is added to coef when it should be", {
   
   # column doesn't exist with a 2 level covariate 
-  emuRes1 <- emuFit(Y = Y0, X = X2_base, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes1 <- emuFit(Y = Y0, X = X2_base, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_false("zero_comparison" %in% names(emuRes1$coef))
   
   # column doesn't exist when no zero-comparison parameters 
-  emuRes2 <- emuFit(Y = Y, X = X1_base, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes2 <- emuFit(Y = Y, X = X1_base, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_false("zero_comparison" %in% names(emuRes2$coef))
   
   # column does exist when there are zero-comparison parameters
-  emuRes3 <- emuFit(Y = Y0, X = X1_base, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes3 <- emuFit(Y = Y0, X = X1_base, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_true("zero_comparison" %in% names(emuRes3$coef))
   
   # column does exist in the presence of continuous covariate 
-  emuRes4 <- emuFit(Y = Y0, X = X4_base, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes4 <- emuFit(Y = Y0, X = X4_base, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_true("zero_comparison" %in% names(emuRes4$coef))
   
 })
 
 test_that("remove_zero_comparison_pvals argument works in different ways", {
   
-  expect_error(emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = 15))
+  expect_error(emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = 15,
+                      match_row_names = FALSE))
   
   emuRes1 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = TRUE,
-                    test_kj = data.frame(k = 2, j = 1))
+                    test_kj = data.frame(k = 2, j = 1),
+                    match_row_names = FALSE)
   expect_true(is.na(emuRes1$coef$pval[1]))
   emuRes2 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = TRUE,
                     test_kj = data.frame(k = 2, j = 1), use_fullmodel_info = TRUE,
-                    return_both_score_pvals = TRUE)
+                    return_both_score_pvals = TRUE,
+                    match_row_names = FALSE)
   expect_true(is.na(emuRes2$coef$score_pval_full_info[1]) &  
                 is.na(emuRes2$coef$score_pval_null_info[1]))
   emuRes3 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = 0.5,
-                    test_kj = data.frame(k = 2, j = 1:2))
+                    test_kj = data.frame(k = 2, j = 1:2),
+                    match_row_names = FALSE)
   expect_true(is.na(emuRes3$coef$pval[1]) || emuRes3$coef$pval[1] > 0.5)
   expect_false(is.na(emuRes3$coef$pval[2]))
   emuRes4 <- emuFit(Y = Y0, X = X1_base, remove_zero_comparison_pvals = FALSE,
-                    test_kj = data.frame(k = 2, j = 1))
+                    test_kj = data.frame(k = 2, j = 1),
+                    match_row_names = FALSE)
   expect_true(emuRes4$coef$zero_comparison[1] & !is.na(emuRes4$coef$pval[1]))
   
 })
@@ -84,23 +93,28 @@ test_that("remove_zero_comparison_pvals argument works in different ways", {
 test_that("zero_comparison column is added to coef when it should be, model.matrix X", {
   
   # column doesn't exist with a 2 level covariate 
-  emuRes1 <- emuFit(Y = Y0, X = X2, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes1 <- emuFit(Y = Y0, X = X2, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_false("zero_comparison" %in% names(emuRes1$coef))
   
   # column doesn't exist when no zero-comparison parameters 
-  emuRes2 <- emuFit(Y = Y, X = X1, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes2 <- emuFit(Y = Y, X = X1, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_false("zero_comparison" %in% names(emuRes2$coef))
   
   # column does exist when there are zero-comparison parameters
-  emuRes3 <- emuFit(Y = Y0, X = X1, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes3 <- emuFit(Y = Y0, X = X1, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_true("zero_comparison" %in% names(emuRes3$coef))
   
   # column does exist in the presence of continuous covariate 
-  emuRes4 <- emuFit(Y = Y0, X = X4, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes4 <- emuFit(Y = Y0, X = X4, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_true("zero_comparison" %in% names(emuRes4$coef))
   
   # column does exist when there are multiple category covariates 
-  emuRes5 <- emuFit(Y = Y0, X = X5, run_score_tests = FALSE, compute_cis = FALSE)
+  emuRes5 <- emuFit(Y = Y0, X = X5, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE)
   expect_true("zero_comparison" %in% names(emuRes5$coef))
   expect_true(emuRes5$coef$zero_comparison[1])
   expect_false(emuRes5$coef$zero_comparison[13])

--- a/vignettes/intro_radEmu.Rmd
+++ b/vignettes/intro_radEmu.Rmd
@@ -191,13 +191,15 @@ To set up this test, we can again run `emuFit`, giving it the fitted values that
 
   - `formula`, `data` and `Y` are as before
   - `B` is our previous fitted object (the output of `emuFit`)
-  - `test_kj` a dataframe listing the indices of the parameters (in `ch_fit$B`) that we want to test. Below we show how to identify these, but `j = 3` is F. nucleatum and `j = 36` is the *Eubacterium* meta mOTU. 
+  - `test_kj` a dataframe listing the indices of the parameters (in `ch_fit$B`) that we want to test. Below we show how to identify these, but `j = 3` is F. nucleatum and `j = 36` is the *Eubacterium* meta mOTU. Note that while `test_kj` was an optional argument in previous software versions, in `radEmu` v2.0.0.0 and forward `test_kj` is required when `run_score_tests = TRUE`. 
 
 ```{r}
 taxa_to_test <- c(which(str_detect(restricted_mOTU_names, "0777")), 
                   which(str_detect(restricted_mOTU_names, "7116")))
+design <- make_design_matrix(formula = ~ Group, data = wirbel_sample[ch_study_obs, ])
+colnames(design)
+covariate_to_test <- 2 # we see in the previous line that the covariate we care about corresponds to the second column of the design matrix
 ch_fit$B %>% rownames
-covariate_to_test <- 2 #which("GroupCRC" == ch_fit$B %>% rownames) # TODO(AW)
 two_robust_score_tests <- emuFit(formula = ~ Group,
                                  data = wirbel_sample[ch_study_obs, ],
                                  B = ch_fit$B,


### PR DESCRIPTION
updating `emuFit()` so that when `run_score_tests = TRUE`, the argument `test_kj` is required instead of optional. Noting this in the vignette, and updating tests to now use this behavior. Updating the package version number to reflect this breaking change (non-backwards compatible) and adding a news.md file to explain this and future version incrementations to users.