### PR TITLE
make sure multiple arguments works when returning null B

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -489,7 +489,7 @@ emuFit <- function(Y,
         if (return_nullB) {
           null_B <- test_result$null_B
           for (k in 1:p) {
-            null_B[k, ] <- null_B[k, ] - constraint_fn(null_B[k, ])
+            null_B[k, ] <- null_B[k, ] - constraint_fn[[k]](null_B[k, ])
           }
           nullB_list[[test_ind]] <- null_B
         }

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -681,9 +681,11 @@ test_that("multiple constraint functions can be submitted", {
   res1 <- emuFit(Y = Y, X = X, compute_cis = FALSE, test_kj = data.frame(k = 2, j = 1),
                 penalize = TRUE, tolerance = 0.1, 
                 constraint_fn = list(function(x) radEmu:::pseudohuber_center(x,0.1), 2), 
-                constraint_grad_fn = list(function(x) radEmu:::dpseudohuber_center_dx(x,0.1), NULL))
+                constraint_grad_fn = list(function(x) radEmu:::dpseudohuber_center_dx(x,0.1), NULL),
+                return_nullB = TRUE)
   expect_true(all.equal(0, radEmu:::pseudohuber_center(res1$B[1, ], 0.1), 0.0001))
   expect_true(all.equal(0, res1$B[2, 2]))
+  expect_true(all.equal(0, res1$null_B[[1]][2, 1], tolerance = 1e-4))
   
   res2 <- emuFit(Y = Y, X = X, compute_cis = FALSE, test_kj = data.frame(k = 2, j = 1),
                 penalize = TRUE, tolerance = 0.1, 


### PR DESCRIPTION
small update to bug in PR #122, make sure multiple arguments can be passed when `return_nullB = TRUE`. 