### PR TITLE
Fix zero comparison

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: radEmu
 Title: Using Relative Abundance Data to Estimate of Multiplicative Differences in Mean Absolute Abundance 
-Version: 2.0.0.0
+Version: 2.0.1.0
 Authors@R: c(person("David", "Clausen", role = c("aut")),
              person("Amy D", "Willis", email = "adwillis@uw.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0002-2802-4317")),
              person("Sarah", "Teichman", role = "aut"))

--- a/R/zero_comparison_check.R
+++ b/R/zero_comparison_check.R
@@ -17,36 +17,41 @@ zero_comparison_check <- function(X, Y) {
       for (col in cat_covs) {
         base_X <- X[, col_assign == col]
         
-        # get indices for each group 
-        n_groups <- ncol(base_X) + 1
-        group_ind <- vector(mode = "list", length = n_groups)
-        group_ind[[1]] <- which(rowSums(base_X) == 0)
+        all_0_1 <- sum(!(base_X %in% c(0, 1))) == 0
+        sum_0_or_1 <- sum(!(rowSums(base_X) %in% c(0, 1))) == 0
         
-        for (i in 1:ncol(base_X)) {
-          group_ind[[i + 1]] <- which(base_X[, i] == 1)
-        }
-        
-        # get Y sums for each group 
-        J <- ncol(Y)
-        group_counts <- matrix(NA, nrow = n_groups, ncol = J)
-        for (i in 1:n_groups) {
-          group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
-        }
-        
-        # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
-        zero_comp <- matrix(FALSE, nrow = n_groups - 1, J)
-        for (i in 1:(n_groups - 1)) {
-          zero_comp[i, ] <- (group_counts[1, ] == 0) * (group_counts[i + 1, ] == 0) == 1
-        }
-        
-        # if there are any zero-comparison parameters
-        if (sum(zero_comp) > 0) {
-          cov <- colnames(base_X)
-          cat <- colnames(Y)
-          new_zero_comp_dat <- data.frame(covariate = rep(cov, each = length(cat)),
-                                      category = rep(cat, length(cov)))
-          new_zero_comp_dat$zero_comparison <- as.vector(t(zero_comp))
-          zero_comp_dat <- rbind(zero_comp_dat, new_zero_comp_dat)
+        if (all_0_1 & sum_0_or_1) {
+          # get indices for each group 
+          n_groups <- ncol(base_X) + 1
+          group_ind <- vector(mode = "list", length = n_groups)
+          group_ind[[1]] <- which(rowSums(base_X) == 0)
+          
+          for (i in 1:ncol(base_X)) {
+            group_ind[[i + 1]] <- which(base_X[, i] == 1)
+          }
+          
+          # get Y sums for each group 
+          J <- ncol(Y)
+          group_counts <- matrix(NA, nrow = n_groups, ncol = J)
+          for (i in 1:n_groups) {
+            group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
+          }
+          
+          # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
+          zero_comp <- matrix(FALSE, nrow = n_groups - 1, J)
+          for (i in 1:(n_groups - 1)) {
+            zero_comp[i, ] <- (group_counts[1, ] == 0) * (group_counts[i + 1, ] == 0) == 1
+          }
+          
+          # if there are any zero-comparison parameters
+          if (sum(zero_comp) > 0) {
+            cov <- colnames(base_X)
+            cat <- colnames(Y)
+            new_zero_comp_dat <- data.frame(covariate = rep(cov, each = length(cat)),
+                                            category = rep(cat, length(cov)))
+            new_zero_comp_dat$zero_comparison <- as.vector(t(zero_comp))
+            zero_comp_dat <- rbind(zero_comp_dat, new_zero_comp_dat)
+          }
         }
       }
       if (nrow(zero_comp_dat) > 0) {

--- a/tests/testthat/test-zero_comparison_check.R
+++ b/tests/testthat/test-zero_comparison_check.R
@@ -8,6 +8,7 @@ form2 <- ~ cov2
 form3 <- ~ cov1 + cov3
 form4 <- ~ cov1 + cov3 + cov4
 form5 <- ~ cov1 + cov2 + cov3 + cov4 + cov5
+form6 <- ~ as.ordered(cov1)
 X1 <- model.matrix(form1, dat)
 X1_base <- matrix(as.vector(X1), nrow = nrow(X1))
 colnames(X1_base) <- colnames(X1)
@@ -21,6 +22,7 @@ X4 <- model.matrix(form4, dat)
 X4_base <- matrix(as.vector(X4), nrow = nrow(X4))
 colnames(X4_base) <- colnames(X4)
 X5 <- model.matrix(form5, dat)
+X6 <- model.matrix(form6, dat)
 Y <- matrix(rpois(18*6, 3), nrow = 18, ncol = 6)
 colnames(Y) <- paste0("category_", 1:ncol(Y))
 Y0 <- Y
@@ -120,4 +122,10 @@ test_that("zero_comparison column is added to coef when it should be, model.matr
   expect_false(emuRes5$coef$zero_comparison[13])
   expect_true(emuRes5$coef$zero_comparison[31])
   expect_false(emuRes5$coef$zero_comparison[32])
+})
+
+# make sure that we aren't flagging ordered factors
+test_that("not flagging ordered factors mistakenly", {
+  zero_comparison_res <- zero_comparison_check(X = X6, Y = Y0)
+  expect_null(zero_comparison_res)
 })


### PR DESCRIPTION
Address issue #135 to avoid mistakenly flagging parameters as "zero-comparison" when we have a design matrix that involves an ordered factor. 