### PR TITLE
add `na.rm` behavior to pseudohuber median and make small fix to micro wald procedure

### DIFF
--- a/R/dpseudohuber_median_dx.R
+++ b/R/dpseudohuber_median_dx.R
@@ -4,6 +4,10 @@
 #' @param d Smoothing parameter, by default set to \code{0.1}. As \code{d} approaches 
 #' \code{0} the pseudo-Huber median function approaches the median and as \code{d} approaches 
 #' infinity this function approaches the mean. 
+#' @param na.rm Passed to \code{pseudohuber_median}, default is FALSE, if FALSE then when 
+#' \code{x} includes at least one NA value then NA is returned, if TRUE then when \code{x} 
+#' includes at least one NA value then that value is removed and the pseudo-Huber median 
+#' is computed without it.
 #'
 #' @return The derivative of the calculated pseudo-Huber smoothed median over \code{x} with smoothing 
 #' parameter \code{d}. 
@@ -16,15 +20,16 @@
 #' @export
 #'
 dpseudohuber_median_dx <- function(x,
-                                   d = 0.1){
-  ps_center <- pseudohuber_median(x,d)
+                                   d = 0.1,
+                                   na.rm = FALSE){
+  ps_center <- pseudohuber_median(x,d, na.rm = na.rm)
   scaled_sq <- ((x - ps_center)/d)^2
   #derivation of why the following is the derivative of 
   #the pseudohuber centering is given in supplement of 
   #Willis & Clausen (2024)
   w <- sqrt(1/(1 + scaled_sq))
   w3 <- w^3
-  return((w3/sum(w3)))
+  return((w3/sum(w3, na.rm = na.rm)))
 }
 
 #' @rdname dpseudohuber_median_dx

--- a/R/micro_wald.R
+++ b/R/micro_wald.R
@@ -106,7 +106,7 @@ micro_wald <- function(Y,
     }
     
     H <- matrix(0,nrow = p, ncol = J - 1 )
-    H[null_k,] <- constraint_grad_fn[[k]](B[null_k,])[-j_ref]
+    H[null_k,] <- constraint_grad_fn[[null_k]](B[null_k,])[-j_ref]
     
     
     if(null_j != j_ref){

--- a/man/dpseudohuber_median_dx.Rd
+++ b/man/dpseudohuber_median_dx.Rd
@@ -5,9 +5,9 @@
 \alias{dpsuedohuber_median_dx}
 \title{Calculate the derivative to the pseudo-Huber smoothed median}
 \usage{
-dpseudohuber_median_dx(x, d = 0.1)
+dpseudohuber_median_dx(x, d = 0.1, na.rm = FALSE)
 
-dpsuedohuber_median_dx(x, d = 0.1)
+dpsuedohuber_median_dx(x, d = 0.1, na.rm = FALSE)
 }
 \arguments{
 \item{x}{A vector to calculate the derivative of the pseudo-Huber smoothed median for.}
@@ -15,6 +15,11 @@ dpsuedohuber_median_dx(x, d = 0.1)
 \item{d}{Smoothing parameter, by default set to \code{0.1}. As \code{d} approaches
 \code{0} the pseudo-Huber median function approaches the median and as \code{d} approaches
 infinity this function approaches the mean.}
+
+\item{na.rm}{Passed to \code{pseudohuber_median}, default is FALSE, if FALSE then when
+\code{x} includes at least one NA value then NA is returned, if TRUE then when \code{x}
+includes at least one NA value then that value is removed and the pseudo-Huber median
+is computed without it.}
 }
 \value{
 The derivative of the calculated pseudo-Huber smoothed median over \code{x} with smoothing

--- a/man/pseudohuber_median.Rd
+++ b/man/pseudohuber_median.Rd
@@ -5,9 +5,9 @@
 \alias{psuedohuber_median}
 \title{Calculate the pseudo-Huber smoothed median}
 \usage{
-pseudohuber_median(x, d = 0.1, tolerance = 1e-08)
+pseudohuber_median(x, d = 0.1, tolerance = 1e-08, na.rm = FALSE)
 
-psuedohuber_median(x, d = 0.1, tolerance = 1e-08)
+psuedohuber_median(x, d = 0.1, tolerance = 1e-08, na.rm = FALSE)
 }
 \arguments{
 \item{x}{A vector to calculate the pseudo-Huber smoothed median for.}
@@ -18,6 +18,10 @@ this function approaches the mean.}
 
 \item{tolerance}{Tolerance used to determine convergence in the algorithm used
 to calculate this function value.}
+
+\item{na.rm}{Default is FALSE, if FALSE then when \code{x} includes at least one
+NA value then NA is returned, if TRUE then when \code{x} includes at least one
+NA value then that value is removed and the pseudo-Huber median is computed without it.}
 }
 \value{
 The calculated pseudo-Huber smoothed median over \code{x} with smoothing


### PR DESCRIPTION
add `na.rm` parameter to `pseudohuber_median` and `dpseudohuber_median_dx` that acts like `na.rm` in `mean` - as mentioned in issue #137 