### PR TITLE
address small bug in `zero_comparison_check` 

### DIFF
--- a/R/zero_comparison_check.R
+++ b/R/zero_comparison_check.R
@@ -34,7 +34,7 @@ zero_comparison_check <- function(X, Y) {
           J <- ncol(Y)
           group_counts <- matrix(NA, nrow = n_groups, ncol = J)
           for (i in 1:n_groups) {
-            group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
+            group_counts[i, ] <- colSums(Y[group_ind[[i]], , drop = FALSE])
           }
           
           # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison
@@ -95,7 +95,7 @@ zero_comparison_check <- function(X, Y) {
         J <- ncol(Y)
         group_counts <- matrix(NA, nrow = n_groups, ncol = J)
         for (i in 1:n_groups) {
-          group_counts[i, ] <- colSums(Y[group_ind[[i]], ])
+          group_counts[i, ] <- colSums(Y[group_ind[[i]], , drop = FALSE])
         }
         
         # get matrix that is (p - 1) x J that gives whether or not parameter is zero-comparison

--- a/tests/testthat/test-zero_comparison_check.R
+++ b/tests/testthat/test-zero_comparison_check.R
@@ -129,3 +129,12 @@ test_that("not flagging ordered factors mistakenly", {
   zero_comparison_res <- zero_comparison_check(X = X6, Y = Y0)
   expect_null(zero_comparison_res)
 })
+
+# avoid error when there is a covariate level with a single sample
+test_that("no error when level with single samples", {
+  X_sm <- X1[1:13, ]
+  expect_silent(emuRes <- emuFit(Y = Y[1:13, ], X = X_sm, run_score_tests = FALSE, compute_cis = FALSE,
+                    match_row_names = FALSE))
+  expect_silent(emuRes <- emuFit(Y = Y[1:13, ], formula = form1, data = dat[1:13, ], 
+                                 run_score_tests = FALSE, compute_cis = FALSE, match_row_names = FALSE))
+})


### PR DESCRIPTION
address small bug in `zero_comparison_check` when data with single sample size for a covariate level, add test for this case that previously failed, now passes