### PR TITLE
Let `k` in `test_kj` be a covariate name 

### DIFF
--- a/R/emuFit.R
+++ b/R/emuFit.R
@@ -47,11 +47,11 @@
 #' @param compute_cis logical: compute and return Wald CIs? Default is `TRUE`.
 #' @param run_score_tests logical: perform robust score testing? Default is TRUE.
 #' @param test_kj a data frame whose rows give coordinates (in category j and
-#' covariate k) of elements of B to construct hypothesis tests for. If you don't know
-#' which indices k correspond to the covariate(s) that you would like to test, run the function
-#' \code{radEmu::make_design_matrix()} in order to view the design matrix, and identify which
-#' column of the design matrix corresponds to each covariate in your model. This argument is required when
-#' running score tests.
+#' covariate k) of elements of B to construct hypothesis tests for. `k` could also be the name of a covariate 
+#' included in `X` or `data`. If you don't know which coordinates k correspond to the covariate(s) that you 
+#' would like to test, run the function \code{radEmu::make_design_matrix()} in order to view the design matrix,
+#' and identify which column of the design matrix corresponds to each covariate in your model. This argument 
+#' is required when running score tests.
 #' @param null_fit_alg Which null fitting algorithm to use for score tests: \code{"constraint_sandwich"} or 
 #' \code{"augmented_lagrangian"}. Default and recommended approach is \code{"constraint_sandwich"}, unless \code{J < 20}.
 #' @param B_null_list list of starting values of coefficient matrix (p x J) for null estimation for score testing. This should either 

--- a/man/emuFit.Rd
+++ b/man/emuFit.Rd
@@ -110,11 +110,11 @@ Used in estimation.}
 \item{run_score_tests}{logical: perform robust score testing? Default is TRUE.}
 
 \item{test_kj}{a data frame whose rows give coordinates (in category j and
-covariate k) of elements of B to construct hypothesis tests for. If you don't know
-which indices k correspond to the covariate(s) that you would like to test, run the function
-\code{radEmu::make_design_matrix()} in order to view the design matrix, and identify which
-column of the design matrix corresponds to each covariate in your model. This argument is required when
-running score tests.}
+covariate k) of elements of B to construct hypothesis tests for. \code{k} could also be the name of a covariate
+included in \code{X} or \code{data}. If you don't know which coordinates k correspond to the covariate(s) that you
+would like to test, run the function \code{radEmu::make_design_matrix()} in order to view the design matrix,
+and identify which column of the design matrix corresponds to each covariate in your model. This argument
+is required when running score tests.}
 
 \item{null_fit_alg}{Which null fitting algorithm to use for score tests: \code{"constraint_sandwich"} or
 \code{"augmented_lagrangian"}. Default and recommended approach is \code{"constraint_sandwich"}, unless \code{J < 20}.}

--- a/man/emuFit_check.Rd
+++ b/man/emuFit_check.Rd
@@ -45,8 +45,11 @@ be a list with the same length as \code{test_kj}. If you only want to provide st
 include the other elements of the list as \code{NULL}.}
 
 \item{test_kj}{a data frame whose rows give coordinates (in category j and
-covariate k) of elements of B to construct hypothesis tests for. If \code{test_kj}
-is not provided, all elements of B save the intercept row will be tested.}
+covariate k) of elements of B to construct hypothesis tests for. \code{k} could also be the name of a covariate
+included in \code{X} or \code{data}. If you don't know which coordinates k correspond to the covariate(s) that you
+would like to test, run the function \code{radEmu::make_design_matrix()} in order to view the design matrix,
+and identify which column of the design matrix corresponds to each covariate in your model. This argument
+is required when running score tests.}
 
 \item{match_row_names}{logical: Make sure rows on covariate data and response data correspond to
 the same sample by comparing row names and subsetting/reordering if necessary.}

--- a/tests/testthat/test-emuFit.R
+++ b/tests/testthat/test-emuFit.R
@@ -635,6 +635,9 @@ test_that("giving test_kj as valid strings works", {
   colnames(X) <- c("int", "group")
   res <- emuFit(Y = Y, X = X, compute_cis = FALSE, test_kj = data.frame(k = "group", j = "taxon3"),
                 penalize = FALSE, tolerance = 0.1)
+  res1 <- emuFit(Y = Y, X = X, compute_cis = FALSE, test_kj = data.frame(k = 2, j = "taxon3"),
+                 penalize = FALSE, tolerance = 0.1)
+  expect_true(all.equal(res$coef, res1$coef))
   expect_true(!is.na(res$coef$pval[3]))
   expect_error(emuFit(Y = Y, X = X, compute_cis = FALSE, test_kj = data.frame(k = "group", j = "taxa3"),
                       penalize = FALSE, tolerance = 0.1))

--- a/tests/testthat/test-emuFit_check.R
+++ b/tests/testthat/test-emuFit_check.R
@@ -20,7 +20,9 @@ Y <- radEmu:::simulate_data(n = n,
 rownames(X) <- paste0("Sample_",1:12)
 rownames(Y) <- paste0("Sample_",1:12)
 
-covariates <- data.frame(group = X[,2])
+covariates <- data.frame(group = X[,2],
+                         cat = rep(c("A", "B", "C"), each = 4))
+other_covariates <- model.matrix(~cat, covariates)
 
 test_that("when X has a missing value, appropriate error hit", {
   X[2, 2] <- NA
@@ -37,3 +39,19 @@ test_that("when X has a missing value, appropriate error hit", {
     fixed = TRUE
   ))
 })
+
+test_that("when k in test_kj is a string it works", {
+  expect_silent(emuFit(Y = Y, formula = ~ group, data = covariates, 
+                       test_kj = data.frame(j = 2, k = "group")))
+  res1 <- emuFit(Y = Y, formula = ~ cat, data = covariates, 
+                       test_kj = data.frame(j = 2, k = "cat"))
+  expect_true(sum(!(is.na(res1$coef$score_stat))) == 2)
+  res2 <- emuFit(Y = Y, formula = ~ cat, data = covariates, 
+                test_kj = data.frame(j = 2, k = "catB"))
+  expect_true(all.equal(res1$coef[2, ], res2$coef[2, ]))
+  res3 <- emuFit(Y = Y, formula = ~ group + cat, data = covariates, 
+                 test_kj = data.frame(j = 2, k = c(2, "cat")))
+  expect_true(sum(!(is.na(res3$coef$score_stat))) == 3)
+})
+
+  


### PR DESCRIPTION
`k` can either be numeric, a string that matches a column name of `X`, or a string that starts one or more column names of `X` (this last case corresponds to a formula like `~ Group` where `Group` has values in `c("A", "B", "C")`, and then will test all covariates of the form `GroupB`, `GroupC`). 